### PR TITLE
fix: Handle partial reads of messages from TCP socket

### DIFF
--- a/parser/partial_parser.go
+++ b/parser/partial_parser.go
@@ -1,0 +1,155 @@
+package parser
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+)
+
+type partialMessageParserState int
+
+const (
+	Start   partialMessageParserState = 0
+	TopLine                           = 1
+	Headers                           = 2
+	Content                           = 3
+)
+
+var (
+	contentLengthHeader = bytes.NewBufferString("content-length:")
+)
+
+type PartialMessageParser struct {
+	state partialMessageParserState
+
+	inputBuffer_ *bytes.Buffer
+	currentLine_ *bytes.Buffer
+
+	hadContentLengthHeader bool
+	contentBytesLeft       int
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (p *PartialMessageParser) reset() {
+	p.state = Start
+	p.hadContentLengthHeader = false
+	p.contentBytesLeft = 0
+	p.inputBuffer_.Reset()
+	p.currentLine_.Reset()
+}
+
+func endsWithCRLF(buffer []byte) bool {
+	return len(buffer) >= 2 && buffer[len(buffer)-1] == '\n' && buffer[len(buffer)-2] == '\r'
+}
+
+func endsWithDoubleCRLF(buffer []byte) bool {
+	return len(buffer) >= 4 &&
+		buffer[len(buffer)-1] == '\n' &&
+		buffer[len(buffer)-2] == '\r' &&
+		buffer[len(buffer)-3] == '\n' &&
+		buffer[len(buffer)-4] == '\r'
+}
+
+func isContentLengthHeader(buffer []byte) bool {
+	if len(buffer) < contentLengthHeader.Len() {
+		return false
+	}
+
+	return bytes.EqualFold(contentLengthHeader.Bytes(), buffer[0:contentLengthHeader.Len()])
+}
+
+func (p *PartialMessageParser) Process(data []byte) (messages [][]byte, err error) {
+	i := 0
+
+	if p.currentLine_ == nil {
+		p.currentLine_ = bytes.NewBuffer(nil)
+	}
+
+	if p.inputBuffer_ == nil {
+		p.inputBuffer_ = bytes.NewBuffer(nil)
+	}
+
+	for i < len(data) {
+		dataByte := data[i]
+		switch p.state {
+		case Start:
+			{
+				if dataByte != '\r' && dataByte != '\n' {
+					p.state = TopLine
+				} else {
+					i++
+				}
+			}
+		case TopLine:
+			{
+				p.inputBuffer_.WriteByte(dataByte)
+				i++
+
+				if dataByte == '\n' && endsWithCRLF(p.inputBuffer_.Bytes()) {
+					p.state = Headers
+				}
+			}
+		case Headers:
+			{
+				p.inputBuffer_.WriteByte(dataByte)
+				p.currentLine_.WriteByte(dataByte)
+
+				i++
+
+				if dataByte == '\n' && endsWithCRLF(p.currentLine_.Bytes()) {
+					if isContentLengthHeader(p.currentLine_.Bytes()) {
+						str := p.currentLine_.Bytes()
+						str = str[contentLengthHeader.Len() : len(str)-2]
+						str = bytes.TrimSpace(str)
+
+						p.contentBytesLeft, err = strconv.Atoi(string(str))
+						if err != nil {
+							return nil, err
+						}
+
+						p.hadContentLengthHeader = true
+					}
+
+					p.currentLine_.Reset()
+
+					// Each message header line must end with CRLF, and there must be one line containing only CRLF between headers and body
+					if endsWithDoubleCRLF(p.inputBuffer_.Bytes()) {
+						p.state = Content
+
+						if !p.hadContentLengthHeader {
+							return nil, errors.New("Missing Content-Length header")
+						}
+					}
+				}
+
+				if p.state == Content && p.contentBytesLeft == 0 {
+					messages = append(messages, p.inputBuffer_.Bytes())
+					p.reset()
+				}
+			}
+		case Content:
+			{
+				if p.contentBytesLeft > 0 {
+					bytesToConsume := min(p.contentBytesLeft, len(data)-i)
+					p.inputBuffer_.Write(data[i : i+bytesToConsume])
+					i += bytesToConsume
+					p.contentBytesLeft -= bytesToConsume
+
+				}
+
+				if p.contentBytesLeft == 0 {
+					messages = append(messages, p.inputBuffer_.Bytes())
+					p.reset()
+				}
+			}
+		}
+	}
+
+	return
+}

--- a/parser/partial_parser_test.go
+++ b/parser/partial_parser_test.go
@@ -1,0 +1,698 @@
+package parser
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var CR = []byte{'\r'}
+var LF = []byte{'\n'}
+
+func TestIsContentLengthHeader(t *testing.T) {
+	assert.False(t, isContentLengthHeader(bytes.NewBufferString("").Bytes()))
+	assert.False(t, isContentLengthHeader(bytes.NewBufferString("a").Bytes()))
+
+	assert.False(t, isContentLengthHeader(bytes.NewBufferString("content-length").Bytes()))
+	assert.True(t, isContentLengthHeader(bytes.NewBufferString("content-length:").Bytes()))
+	assert.True(t, isContentLengthHeader(bytes.NewBufferString("cOnTeNt-LeNgTh:").Bytes()))
+}
+
+func TestParserSkipsWhitespace(t *testing.T) {
+	t.Skip()
+	topLineFragment := bytes.NewBufferString("\r\n\n\rI")
+
+	parser := PartialMessageParser{}
+	msgBytes := topLineFragment.Bytes()
+
+	for _, b := range msgBytes[:len(msgBytes)-1] {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Start), parser.state)
+	}
+
+	messages, err := parser.Process([]byte{msgBytes[len(msgBytes)-1]})
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(TopLine), parser.state)
+}
+
+func TestParseTopLineUntilCRLF(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0")
+
+	parser := PartialMessageParser{}
+	msgBytes := topLine.Bytes()
+
+	for _, b := range msgBytes {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(TopLine), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(TopLine), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+}
+
+func TestParseOneHeaderAndThenALineWithOnlyCRLFZeroContentLength(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0\r\n")
+	singleHeader := bytes.NewBufferString("Content-Length: 0\r\n")
+
+	parser := PartialMessageParser{}
+	parser.Process(topLine.Bytes())
+
+	singleHeaderBytes := singleHeader.Bytes()
+
+	for _, b := range singleHeaderBytes {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Headers), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Nil(t, err)
+	assert.Len(t, messages, 1)
+	assert.Equal(t, partialMessageParserState(Start), parser.state)
+}
+
+func TestParseOneHeaderAndThenALineWithOnlyCRLFNonZeroContentLength(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0\r\n")
+	singleHeader := bytes.NewBufferString("Content-Length: 1\r\n")
+
+	parser := PartialMessageParser{}
+	parser.Process(topLine.Bytes())
+
+	singleHeaderBytes := singleHeader.Bytes()
+
+	for _, b := range singleHeaderBytes {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Headers), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Content), parser.state)
+}
+
+func TestParseTwoHeadersAndThenALineWithOnlyCRLFZeroContentLength(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0\r\n")
+	threeHeaders := bytes.NewBufferString("Pizza: 123\r\nPie: \"adsfad\"\r\nContent-Length: 0\r\n")
+
+	parser := PartialMessageParser{}
+	parser.Process(topLine.Bytes())
+
+	threeHeaderBytes := threeHeaders.Bytes()
+
+	for _, b := range threeHeaderBytes {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Headers), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Len(t, messages, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Start), parser.state)
+}
+
+func TestParseTwoHeadersAndThenALineWithOnlyCRLFNonZeroContentLength(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0\r\n")
+	threeHeaders := bytes.NewBufferString("Pizza: 123\r\nPie: \"adsfad\"\r\nContent-Length: 1\r\n")
+
+	parser := PartialMessageParser{}
+	parser.Process(topLine.Bytes())
+
+	threeHeaderBytes := threeHeaders.Bytes()
+
+	for _, b := range threeHeaderBytes {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Headers), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Content), parser.state)
+}
+
+func TestParseMessageThatIsMissingContentLengthReturnsError(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0\r\n")
+	singleHeader := bytes.NewBufferString("Pizza: 0\r\n")
+
+	parser := PartialMessageParser{}
+	parser.Process(topLine.Bytes())
+
+	singleHeaderBytes := singleHeader.Bytes()
+
+	for _, b := range singleHeaderBytes {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Headers), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Nil(t, messages)
+	assert.NotNil(t, err)
+	assert.Equal(t, partialMessageParserState(Content), parser.state)
+}
+
+func TestParseMessage(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0\r\n")
+	threeHeaders := bytes.NewBufferString("Pizza: 123\r\nPie: \"adsfad\"\r\nContent-Length: 32\r\n")
+
+	parser := PartialMessageParser{}
+	parser.Process(topLine.Bytes())
+
+	singleHeaderBytes := threeHeaders.Bytes()
+
+	for _, b := range singleHeaderBytes {
+		_, err := parser.Process([]byte{b})
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Headers), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Content), parser.state)
+
+	for i := 0; i < 31; i++ {
+		messages, err := parser.Process([]byte{byte('a')})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Content), parser.state)
+	}
+
+	messages, err = parser.Process([]byte{byte('a')})
+	assert.Len(t, messages, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Start), parser.state)
+
+	message := messages[0]
+	assert.NotNil(t, message)
+	assert.Equal(t, topLine.String()+threeHeaders.String()+"\r\n"+strings.Repeat("a", 32), string(message))
+}
+
+func TestParseTwoMessages(t *testing.T) {
+	topLine := bytes.NewBufferString("INVITE sip:10.5.0.10:5060;transport=tcp SIP/2.0\r\n")
+	threeHeaders := bytes.NewBufferString("Pizza: 123\r\nPie: \"adsfad\"\r\nContent-Length: 32\r\n")
+
+	parser := PartialMessageParser{}
+
+	// Parse one full message first
+	parser.Process(topLine.Bytes())
+	parser.Process(threeHeaders.Bytes())
+	parser.Process(CR)
+	parser.Process(LF)
+	parser.Process(bytes.Repeat([]byte{'a'}, 32))
+
+	assert.Equal(t, partialMessageParserState(Start), parser.state)
+
+	parser.Process(topLine.Bytes())
+
+	singleHeaderBytes := threeHeaders.Bytes()
+
+	for _, b := range singleHeaderBytes {
+		messages, err := parser.Process([]byte{b})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Headers), parser.state)
+	}
+
+	messages, err := parser.Process(CR)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Headers), parser.state)
+
+	messages, err = parser.Process(LF)
+	assert.Nil(t, messages)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Content), parser.state)
+
+	for i := 0; i < 31; i++ {
+		messages, err := parser.Process([]byte{'a'})
+		assert.Nil(t, messages)
+		assert.Nil(t, err)
+		assert.Equal(t, partialMessageParserState(Content), parser.state)
+	}
+
+	messages, err = parser.Process([]byte{'a'})
+	assert.Len(t, messages, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, partialMessageParserState(Start), parser.state)
+
+	message := messages[0]
+	assert.NotNil(t, message)
+	assert.Equal(t, topLine.String()+threeHeaders.String()+"\r\n"+strings.Repeat("a", 32), string(message))
+}
+
+func TestParseFullMessage(t *testing.T) {
+	parser := PartialMessageParser{}
+
+	lines := []string{
+		"INVITE sip:192.168.1.254:5060 SIP/2.0",
+		"Via: SIP/2.0/TCP 192.168.1.155:44861;branch=z9hG4bK954690f3012120bc5d064d3f7b5d8a24;rport",
+		"Call-ID: 25be1c3be64adb89fa2e86772dd99db1",
+		"CSeq: 100 INVITE",
+		"Contact: <sip:192.168.1.155:44861;transport=tcp>;some.tag.here;other-tag=here",
+		"From: <sip:192.168.1.155>;tag=76fb12e7e2241ed6",
+		"To: <sip:192.168.1.254:5060>",
+		"Max-Forwards: 70",
+		"Allow: INVITE,ACK,CANCEL,BYE,UPDATE,INFO,OPTIONS,REFER,NOTIFY",
+		"User-Agent: MyUserAgent v2.3.6. b53ee2632df (DEV) Client",
+		"Supported: replaces,100rel,timer,gruu,path,outbound",
+		"Session-Expires: 1800",
+		"Session-ID: e937754d76855249814a9b7f8b3bf556;remote=00000000000000000000000000000000",
+		"Content-Type: application/sdp",
+		"Content-Length: 3119",
+		"",
+		"v=0",
+		"o=something 8 2 IN IP4 192.168.1.155",
+		"s=-",
+		"c=IN IP4 192.168.1.155",
+		"b=AS:6000",
+		"t=0 0",
+		"a=some-attrs-here",
+		"a=other-tags:v1",
+		"m=audio 2332 RTP/AVP 114 107 108 104 105 9 18 8 0 101 123",
+		"b=TIAS:128000",
+		"a=rtpmap:114 opus/48000/2",
+		"a=fmtp:114 maxaveragebitrate=128000;stereo=1",
+		"a=rtpmap:107 MP4A-LATM/90000",
+		"a=fmtp:107 profile-level-id=25;object=23;bitrate=128000",
+		"a=rtpmap:108 MP4A-LATM/90000",
+		"a=fmtp:108 profile-level-id=24;object=23;bitrate=64000",
+		"a=rtpmap:104 G7221/16000",
+		"a=fmtp:104 bitrate=32000",
+		"a=rtpmap:105 G7221/16000",
+		"a=fmtp:105 bitrate=24000",
+		"a=rtpmap:9 G722/8000",
+		"a=rtpmap:18 G729/8000",
+		"a=fmtp:18 annexb=yes",
+		"a=rtpmap:8 PCMA/8000",
+		"a=rtpmap:0 PCMU/8000",
+		"a=rtpmap:101 telephone-event/8000",
+		"a=fmtp:101 0-15",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=sendrecv",
+		"m=video 2364 RTP/AVP 99 97 126 123",
+		"b=TIAS:6000000",
+		"a=rtpmap:99 H265/90000",
+		"a=fmtp:99 level-id=90;max-lsr=125337600;max-lps=2088960;max-tr=22;max-tc=20;max-fps=6000;x-other-tags=123",
+		"a=rtpmap:97 H264/90000",
+		"a=fmtp:97 packetization-mode=0;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=8160;max-dpb=16320;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:126 H264/90000",
+		"a=fmtp:126 packetization-mode=1;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=8160;max-dpb=16320;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=label:11",
+		"a=answer:full",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=content:main",
+		"a=rtcp-fb:* nack pli",
+		"a=rtcp-fb:* ccm fir",
+		"a=rtcp-fb:* ccm tmmbr",
+		"a=rtcp-fb:* ccm pan",
+		"a=sendrecv",
+		"a=some-video-attr:97 ltrf=3",
+		"a=some-video-attr:126 ltrf=3",
+		"m=application 2439 UDP/BFCP *",
+		"a=setup:actpass",
+		"a=confid:1",
+		"a=userid:18",
+		"a=bfcpver:2 1",
+		"a=floorid:2 mstrm:12",
+		"a=floorctrl:c-s",
+		"a=connection:new",
+		"m=video 2354 RTP/AVP 97 126 96 34 123",
+		"b=TIAS:6000000",
+		"a=rtpmap:97 H264/90000",
+		"a=fmtp:97 packetization-mode=0;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=32400;max-dpb=64800;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:126 H264/90000",
+		"a=fmtp:126 packetization-mode=1;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=32400;max-dpb=64800;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:96 H263-1998/90000",
+		"a=fmtp:96 custom=1280,720,3;custom=1024,768,2;custom=1024,576,2;custom=800,600,2;cif4=2;custom=720,480,2;custom=640,480,2;custom=512,288,2;cif=2;custom=352,240,2;qcif=2;maxbr=30000",
+		"a=rtpmap:34 H263/90000",
+		"a=fmtp:34 cif4=1;cif=1;qcif=1;maxbr=20000",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=label:12",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=content:slides",
+		"a=rtcp-fb:* nack pli",
+		"a=rtcp-fb:* ccm fir",
+		"a=rtcp-fb:* ccm tmmbr",
+		"a=sendrecv",
+		"m=application 2392 RTP/AVP 100",
+		"a=rtpmap:100 H224/4800",
+		"a=sendrecv",
+		"m=application 2455 UDP/UDT/IX *",
+		"a=ixmap:0 ping",
+		"a=ixmap:2 xccp",
+		"a=setup:actpass",
+		"a=fingerprint:sha-1 0A:58:47:C4:8E:74:30:53:5F:AF:5E:25:CB:44:A9:CF:3B:87:D7:BF",
+		"",
+	}
+	msg := bytes.NewBufferString(strings.Join(lines, "\r\n"))
+
+	messages, err := parser.Process(msg.Bytes())
+
+	assert.Len(t, messages, 1)
+	assert.Nil(t, err)
+}
+
+func TestParseDialogWithInviteAckBye(t *testing.T) {
+	parser := PartialMessageParser{}
+
+	lines := []string{
+		"INVITE sip:192.168.1.254:5060 SIP/2.0",
+		"Via: SIP/2.0/TCP 192.168.1.155:41257;branch=z9hG4bK39b286f199521937c935bd60c90c1456;rport",
+		"Call-ID: 7ad13687285b4d1c60cf0f6f745e248e",
+		"CSeq: 100 INVITE",
+		"Contact: <sip:192.168.1.155:41257;transport=tcp>;some.tag.here;other-tag=here",
+		"From: <sip:192.168.1.155>;tag=18721124cc882f28",
+		"To: <sip:192.168.1.254:5060>",
+		"Max-Forwards: 70",
+		"Allow: INVITE,ACK,CANCEL,BYE,UPDATE,INFO,OPTIONS,REFER,NOTIFY",
+		"User-Agent: MyUserAgent v2.3.6. b53ee2632df (DEV) Client",
+		"Supported: replaces,100rel,timer,gruu,path,outbound",
+		"Session-Expires: 1800",
+		"Session-ID: 57cf2c96188b51a29f98b4c57a26fcf7;remote=00000000000000000000000000000000",
+		"Content-Type: application/sdp",
+		"Content-Length: 3119",
+		"",
+		"v=0",
+		"o=something 8 2 IN IP4 192.168.1.155",
+		"s=-",
+		"c=IN IP4 192.168.1.155",
+		"b=AS:6000",
+		"t=0 0",
+		"a=some-attrs-here",
+		"a=other-tags:v1",
+		"m=audio 2352 RTP/AVP 114 107 108 104 105 9 18 8 0 101 123",
+		"b=TIAS:128000",
+		"a=rtpmap:114 opus/48000/2",
+		"a=fmtp:114 maxaveragebitrate=128000;stereo=1",
+		"a=rtpmap:107 MP4A-LATM/90000",
+		"a=fmtp:107 profile-level-id=25;object=23;bitrate=128000",
+		"a=rtpmap:108 MP4A-LATM/90000",
+		"a=fmtp:108 profile-level-id=24;object=23;bitrate=64000",
+		"a=rtpmap:104 G7221/16000",
+		"a=fmtp:104 bitrate=32000",
+		"a=rtpmap:105 G7221/16000",
+		"a=fmtp:105 bitrate=24000",
+		"a=rtpmap:9 G722/8000",
+		"a=rtpmap:18 G729/8000",
+		"a=fmtp:18 annexb=yes",
+		"a=rtpmap:8 PCMA/8000",
+		"a=rtpmap:0 PCMU/8000",
+		"a=rtpmap:101 telephone-event/8000",
+		"a=fmtp:101 0-15",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=sendrecv",
+		"m=video 2366 RTP/AVP 99 97 126 123",
+		"b=TIAS:6000000",
+		"a=rtpmap:99 H265/90000",
+		"a=fmtp:99 level-id=90;max-lsr=125337600;max-lps=2088960;max-tr=22;max-tc=20;max-fps=6000;x-extra-tags=123",
+		"a=rtpmap:97 H264/90000",
+		"a=fmtp:97 packetization-mode=0;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=8160;max-dpb=16320;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:126 H264/90000",
+		"a=fmtp:126 packetization-mode=1;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=8160;max-dpb=16320;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=label:11",
+		"a=answer:full",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=content:main",
+		"a=rtcp-fb:* nack pli",
+		"a=rtcp-fb:* ccm fir",
+		"a=rtcp-fb:* ccm tmmbr",
+		"a=rtcp-fb:* ccm pan",
+		"a=sendrecv",
+		"a=some-video-attr:97 ltrf=3",
+		"a=some-video-attr:126 ltrf=3",
+		"m=application 2449 UDP/BFCP *",
+		"a=setup:actpass",
+		"a=confid:1",
+		"a=userid:19",
+		"a=bfcpver:2 1",
+		"a=floorid:2 mstrm:12",
+		"a=floorctrl:c-s",
+		"a=connection:new",
+		"m=video 2354 RTP/AVP 97 126 96 34 123",
+		"b=TIAS:6000000",
+		"a=rtpmap:97 H264/90000",
+		"a=fmtp:97 packetization-mode=0;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=32400;max-dpb=64800;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:126 H264/90000",
+		"a=fmtp:126 packetization-mode=1;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=32400;max-dpb=64800;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:96 H263-1998/90000",
+		"a=fmtp:96 custom=1280,720,3;custom=1024,768,2;custom=1024,576,2;custom=800,600,2;cif4=2;custom=720,480,2;custom=640,480,2;custom=512,288,2;cif=2;custom=352,240,2;qcif=2;maxbr=30000",
+		"a=rtpmap:34 H263/90000",
+		"a=fmtp:34 cif4=1;cif=1;qcif=1;maxbr=20000",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=label:12",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=content:slides",
+		"a=rtcp-fb:* nack pli",
+		"a=rtcp-fb:* ccm fir",
+		"a=rtcp-fb:* ccm tmmbr",
+		"a=sendrecv",
+		"m=application 2408 RTP/AVP 100",
+		"a=rtpmap:100 H224/4800",
+		"a=sendrecv",
+		"m=application 2464 UDP/UDT/IX *",
+		"a=ixmap:0 ping",
+		"a=ixmap:2 xccp",
+		"a=setup:actpass",
+		"a=fingerprint:sha-1 0A:58:47:C4:8E:74:30:53:5F:AF:5E:25:CB:44:A9:CF:3B:87:D7:BF",
+		"ACK sip:192.168.1.254:5060 SIP/2.0",
+		"Via: SIP/2.0/TCP 192.168.1.155:41257;branch=z9hG4bKc02c1e1e78023fde8b20ec9232b0443e;rport",
+		"Call-ID: 7ad13687285b4d1c60cf0f6f745e248e",
+		"CSeq: 100 ACK",
+		"From: <sip:192.168.1.155>;tag=18721124cc882f28",
+		"To: <sip:192.168.1.254:5060>;tag=a0ee9e0a-9032-4083-850f-c75c6a5a9aa5",
+		"Max-Forwards: 70",
+		"Allow: INVITE,ACK,CANCEL,BYE,UPDATE,INFO,OPTIONS,REFER,NOTIFY",
+		"User-Agent: MyUserAgent v2.3.6. b53ee2632df (DEV) Client",
+		"Supported: replaces,100rel,timer,gruu,path,outbound",
+		"Content-Length: 0",
+		"",
+		"BYE sip:192.168.1.254:5060 SIP/2.0",
+		"Via: SIP/2.0/TCP 192.168.1.155:41257;branch=z9hG4bKd4c2f1065004520758880ebc497ebef5;rport",
+		"Call-ID: 7ad13687285b4d1c60cf0f6f745e248e",
+		"CSeq: 116 BYE",
+		"Contact: <sip:192.168.1.155:41257;transport=tcp>;some.tag.here;other-tag=here",
+		"From: <sip:192.168.1.155>;tag=18721124cc882f28",
+		"To: <sip:192.168.1.254:5060>;tag=a0ee9e0a-9032-4083-850f-c75c6a5a9aa5",
+		"Max-Forwards: 70",
+		"Allow: INVITE,ACK,CANCEL,BYE,UPDATE,INFO,OPTIONS,REFER,NOTIFY",
+		"User-Agent: MyUserAgent v. 2.3.6. b53ee2632df (DEV) Client",
+		"Supported: replaces,100rel,timer,gruu,path,outbound",
+		"Content-Length: 0",
+		"",
+		"",
+	}
+
+	msgs := bytes.NewBufferString(strings.Join(lines, "\r\n"))
+	messages, err := parser.Process(msgs.Bytes())
+
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(messages))
+}
+
+func BenchmarkPartialParser(b *testing.B) {
+	lines := []string{
+		"INVITE sip:192.168.1.254:5060 SIP/2.0",
+		"Via: SIP/2.0/TCP 192.168.1.155:41257;branch=z9hG4bK39b286f199521937c935bd60c90c1456;rport",
+		"Call-ID: 7ad13687285b4d1c60cf0f6f745e248e",
+		"CSeq: 100 INVITE",
+		"Contact: <sip:192.168.1.155:41257;transport=tcp>;some.tag.here;other-tag=here",
+		"From: <sip:192.168.1.155>;tag=18721124cc882f28",
+		"To: <sip:192.168.1.254:5060>",
+		"Max-Forwards: 70",
+		"Allow: INVITE,ACK,CANCEL,BYE,UPDATE,INFO,OPTIONS,REFER,NOTIFY",
+		"User-Agent: MyUserAgent v2.3.6. b53ee2632df (DEV) Client",
+		"Supported: replaces,100rel,timer,gruu,path,outbound",
+		"Session-Expires: 1800",
+		"Session-ID: 57cf2c96188b51a29f98b4c57a26fcf7;remote=00000000000000000000000000000000",
+		"Content-Type: application/sdp",
+		"Content-Length: 3119",
+		"",
+		"v=0",
+		"o=something 8 2 IN IP4 192.168.1.155",
+		"s=-",
+		"c=IN IP4 192.168.1.155",
+		"b=AS:6000",
+		"t=0 0",
+		"a=some-attrs-here",
+		"a=other-tags:v1",
+		"m=audio 2352 RTP/AVP 114 107 108 104 105 9 18 8 0 101 123",
+		"b=TIAS:128000",
+		"a=rtpmap:114 opus/48000/2",
+		"a=fmtp:114 maxaveragebitrate=128000;stereo=1",
+		"a=rtpmap:107 MP4A-LATM/90000",
+		"a=fmtp:107 profile-level-id=25;object=23;bitrate=128000",
+		"a=rtpmap:108 MP4A-LATM/90000",
+		"a=fmtp:108 profile-level-id=24;object=23;bitrate=64000",
+		"a=rtpmap:104 G7221/16000",
+		"a=fmtp:104 bitrate=32000",
+		"a=rtpmap:105 G7221/16000",
+		"a=fmtp:105 bitrate=24000",
+		"a=rtpmap:9 G722/8000",
+		"a=rtpmap:18 G729/8000",
+		"a=fmtp:18 annexb=yes",
+		"a=rtpmap:8 PCMA/8000",
+		"a=rtpmap:0 PCMU/8000",
+		"a=rtpmap:101 telephone-event/8000",
+		"a=fmtp:101 0-15",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=sendrecv",
+		"m=video 2366 RTP/AVP 99 97 126 123",
+		"b=TIAS:6000000",
+		"a=rtpmap:99 H265/90000",
+		"a=fmtp:99 level-id=90;max-lsr=125337600;max-lps=2088960;max-tr=22;max-tc=20;max-fps=6000;x-extra-tags=123",
+		"a=rtpmap:97 H264/90000",
+		"a=fmtp:97 packetization-mode=0;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=8160;max-dpb=16320;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:126 H264/90000",
+		"a=fmtp:126 packetization-mode=1;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=8160;max-dpb=16320;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=label:11",
+		"a=answer:full",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=content:main",
+		"a=rtcp-fb:* nack pli",
+		"a=rtcp-fb:* ccm fir",
+		"a=rtcp-fb:* ccm tmmbr",
+		"a=rtcp-fb:* ccm pan",
+		"a=sendrecv",
+		"a=some-video-attr:97 ltrf=3",
+		"a=some-video-attr:126 ltrf=3",
+		"m=application 2449 UDP/BFCP *",
+		"a=setup:actpass",
+		"a=confid:1",
+		"a=userid:19",
+		"a=bfcpver:2 1",
+		"a=floorid:2 mstrm:12",
+		"a=floorctrl:c-s",
+		"a=connection:new",
+		"m=video 2354 RTP/AVP 97 126 96 34 123",
+		"b=TIAS:6000000",
+		"a=rtpmap:97 H264/90000",
+		"a=fmtp:97 packetization-mode=0;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=32400;max-dpb=64800;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:126 H264/90000",
+		"a=fmtp:126 packetization-mode=1;profile-level-id=428016;max-br=5000;max-mbps=490000;max-fs=32400;max-dpb=64800;max-smbps=490000;max-fps=6000",
+		"a=rtpmap:96 H263-1998/90000",
+		"a=fmtp:96 custom=1280,720,3;custom=1024,768,2;custom=1024,576,2;custom=800,600,2;cif4=2;custom=720,480,2;custom=640,480,2;custom=512,288,2;cif=2;custom=352,240,2;qcif=2;maxbr=30000",
+		"a=rtpmap:34 H263/90000",
+		"a=fmtp:34 cif4=1;cif=1;qcif=1;maxbr=20000",
+		"a=rtpmap:123 x-ulpfecuc/8000",
+		"a=fmtp:123 multi_ssrc=1;feedback=0;max_esel=1450;m=8;max_n=42;FEC_ORDER=FEC_SRTP;non_seq=1",
+		"a=label:12",
+		"a=extmap:4 http://some.url.goes.here.com/foobarbazbaq",
+		"a=content:slides",
+		"a=rtcp-fb:* nack pli",
+		"a=rtcp-fb:* ccm fir",
+		"a=rtcp-fb:* ccm tmmbr",
+		"a=sendrecv",
+		"m=application 2408 RTP/AVP 100",
+		"a=rtpmap:100 H224/4800",
+		"a=sendrecv",
+		"m=application 2464 UDP/UDT/IX *",
+		"a=ixmap:0 ping",
+		"a=ixmap:2 xccp",
+		"a=setup:actpass",
+		"a=fingerprint:sha-1 0A:58:47:C4:8E:74:30:53:5F:AF:5E:25:CB:44:A9:CF:3B:87:D7:BF",
+		"ACK sip:192.168.1.254:5060 SIP/2.0",
+		"Via: SIP/2.0/TCP 192.168.1.155:41257;branch=z9hG4bKc02c1e1e78023fde8b20ec9232b0443e;rport",
+		"Call-ID: 7ad13687285b4d1c60cf0f6f745e248e",
+		"CSeq: 100 ACK",
+		"From: <sip:192.168.1.155>;tag=18721124cc882f28",
+		"To: <sip:192.168.1.254:5060>;tag=a0ee9e0a-9032-4083-850f-c75c6a5a9aa5",
+		"Max-Forwards: 70",
+		"Allow: INVITE,ACK,CANCEL,BYE,UPDATE,INFO,OPTIONS,REFER,NOTIFY",
+		"User-Agent: MyUserAgent v2.3.6. b53ee2632df (DEV) Client",
+		"Supported: replaces,100rel,timer,gruu,path,outbound",
+		"Content-Length: 0",
+		"",
+		"BYE sip:192.168.1.254:5060 SIP/2.0",
+		"Via: SIP/2.0/TCP 192.168.1.155:41257;branch=z9hG4bKd4c2f1065004520758880ebc497ebef5;rport",
+		"Call-ID: 7ad13687285b4d1c60cf0f6f745e248e",
+		"CSeq: 116 BYE",
+		"Contact: <sip:192.168.1.155:41257;transport=tcp>;some.tag.here;other-tag=here",
+		"From: <sip:192.168.1.155>;tag=18721124cc882f28",
+		"To: <sip:192.168.1.254:5060>;tag=a0ee9e0a-9032-4083-850f-c75c6a5a9aa5",
+		"Max-Forwards: 70",
+		"Allow: INVITE,ACK,CANCEL,BYE,UPDATE,INFO,OPTIONS,REFER,NOTIFY",
+		"User-Agent: MyUserAgent v. 2.3.6. b53ee2632df (DEV) Client",
+		"Supported: replaces,100rel,timer,gruu,path,outbound",
+		"Content-Length: 0",
+		"",
+		"",
+	}
+
+	msgs := bytes.NewBufferString(strings.Join(lines, "\r\n"))
+	parser := PartialMessageParser{}
+
+	b.ResetTimer()
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		parser.Process(msgs.Bytes())
+	}
+}

--- a/sip/sip.go
+++ b/sip/sip.go
@@ -26,6 +26,12 @@ type Parser interface {
 	ParseSIP(data []byte) (Message, error)
 }
 
+// PartialParser extracts full SIP messages from a stream
+type PartialParser interface {
+	Process(data []byte) error
+	OnMessage(func(msg []byte))
+}
+
 // GenerateBranch returns random unique branch ID.
 func GenerateBranch() string {
 	return GenerateBranchN(16)


### PR DESCRIPTION
Hi,

First of all, thank you for making this library, I've found it very nice to work with for my personal SIP-based project so far.

The systems I work with are capable of producing large SDPs, which easily breaks the current assumption in `tcp.go` that requires all messages to be read in full. Often the headers of an INVITE would be parsed along with the first half of the SDP, and then there would be an attempt to parse the second half of the SDP as if it was a full message.

This commit introduces a mechanism to extract full SIP messages from a continuous stream of bytes. 

The current tests appear to pass with this change.

`HandlePartialMessages` has been added as a way to turn off this functionality for now in case it is needed to work around any issues that may arise. It is enabled by default.