### PR TITLE
Add fuzzer for SIP parser

### DIFF
--- a/parser/parse_address.go
+++ b/parser/parse_address.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -81,6 +82,11 @@ func ParseAddressValue(addressText string, uri *sip.Uri, headerParams sip.Header
 	if uriEnd < 0 {
 		uriEnd = len(addressText)
 	}
+
+	if uriStart > uriEnd {
+		return "", errors.New("Malormed URI")
+	}
+
 	err = ParseUri(addressText[uriStart:uriEnd], uri)
 	if err != nil {
 		return

--- a/parser/parse_address.go
+++ b/parser/parse_address.go
@@ -22,8 +22,9 @@ func ParseAddressValue(addressText string, uri *sip.Uri, headerParams sip.Header
 		case '"':
 			if startQuote < 0 {
 				startQuote = i
+			} else {
+				endQuote = i
 			}
-			endQuote = i
 		case '<':
 			if uriStart > 0 {
 				// This must be additional options parsing

--- a/parser/parse_params.go
+++ b/parser/parse_params.go
@@ -64,7 +64,7 @@ func UnmarshalParams(s string, seperator rune, ending rune, p sip.HeaderParams) 
 	}
 
 	// Do the last one
-	if sep > 0 && n >= 0 {
+	if sep > 0 && n >= 0 && (start < sep) {
 		p.Add(s[start:sep], s[sep+1:n])
 	}
 	// No seperator

--- a/parser/parse_uri.go
+++ b/parser/parse_uri.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/emiago/sipgo/sip"
 )
@@ -25,14 +26,12 @@ func ParseUri(uriStr string, uri *sip.Uri) (err error) {
 }
 
 func uriStateSIP(uri *sip.Uri, s string) (uriFSM, string, error) {
-	switch s[0] {
-	case 'S', 's':
-		if s[3] == 'S' || s[3] == 's' {
-			uri.Encrypted = true
-			return uriStateUser, s[5:], nil
-		}
+	if len(s) >= 4 && strings.EqualFold(s[:4], "sip:") {
 		return uriStateUser, s[4:], nil
-	default:
+	} else if len(s) >= 5 && strings.EqualFold(s[:5], "sips:") {
+		uri.Encrypted = true
+		return uriStateUser, s[5:], nil
+	} else {
 		return uriStateHost, s, nil
 	}
 }

--- a/parser/parse_uri.go
+++ b/parser/parse_uri.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -14,6 +15,9 @@ type uriFSM func(uri *sip.Uri, s string) (uriFSM, string, error)
 // Following https://datatracker.ietf.org/doc/html/rfc3261#section-19.1.1
 // sip:user:password@host:port;uri-parameters?headers
 func ParseUri(uriStr string, uri *sip.Uri) (err error) {
+	if len(uriStr) == 0 {
+		return errors.New("Empty URI")
+	}
 	state := uriStateSIP
 	str := uriStr
 	for state != nil {

--- a/parser/parse_via.go
+++ b/parser/parse_via.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 
@@ -45,6 +46,9 @@ type viaFSM func(h *sip.ViaHeader, s string) (viaFSM, int, error)
 
 func viaStateProtocol(h *sip.ViaHeader, s string) (viaFSM, int, error) {
 	ind := strings.IndexRune(s, '/')
+	if ind < 0 {
+		return nil, 0, errors.New("Malformed protocol name in Via header")
+	}
 	h.ProtocolName = s[:ind]
 	return viaStateProtocolVersion, ind + 1, nil
 }

--- a/parser/parse_via.go
+++ b/parser/parse_via.go
@@ -55,6 +55,9 @@ func viaStateProtocol(h *sip.ViaHeader, s string) (viaFSM, int, error) {
 
 func viaStateProtocolVersion(h *sip.ViaHeader, s string) (viaFSM, int, error) {
 	ind := strings.IndexRune(s, '/')
+	if ind < 0 {
+		return nil, 0, errors.New("Malformed protocol version in Via header")
+	}
 	h.ProtocolVersion = s[:ind]
 	return viaStateProtocolTransport, ind + 1, nil
 }

--- a/parser/parse_via.go
+++ b/parser/parse_via.go
@@ -64,6 +64,9 @@ func viaStateProtocolVersion(h *sip.ViaHeader, s string) (viaFSM, int, error) {
 
 func viaStateProtocolTransport(h *sip.ViaHeader, s string) (viaFSM, int, error) {
 	ind := strings.IndexAny(s, " \t")
+	if ind < 0 {
+		return nil, 0, errors.New("Malformed transport in Via header")
+	}
 	h.Transport = s[:ind]
 	return viaStateHost, ind + 1, nil
 }

--- a/parser/parser_fuzz_test.go
+++ b/parser/parser_fuzz_test.go
@@ -1,0 +1,40 @@
+package parser
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func FuzzParseSipMessage(f *testing.F) {
+	log.Logger = zerolog.New(zerolog.ConsoleWriter{
+		Out:        os.Stdout,
+		TimeFormat: "2006-01-02 15:04:05.000",
+	}).With().Timestamp().Logger().Level(zerolog.WarnLevel)
+
+	if lvl, err := zerolog.ParseLevel(os.Getenv("LOG_LEVEL")); err == nil {
+		log.Logger = log.Level(lvl)
+	}
+
+	rawMsg := []string{
+		"INVITE sip:bob@127.0.0.1:5060 SIP/2.0",
+		"Via: SIP/2.0/UDP 127.0.0.2:5060;branch=z9hG4bK.VYWrxJJyeEJfngAjKXELr8aPYuX8tR22",
+		"From: \"Alice\" <sip:alice@127.0.0.2:5060>;tag=1928301774",
+		"To: \"Bob\" <sip:bob@127.0.0.1:5060>",
+		"Contact: <sip:alice@127.0.0.2:5060;expires=3600>",
+		"Content-Type: application/sdp",
+		"Content-Length: 0",
+		"",
+	}
+
+	f.Add(strings.Join(rawMsg, "\r\n"))
+
+	parser := NewParser()
+
+	f.Fuzz(func(t *testing.T, orig string) {
+		parser.ParseSIP([]byte(orig))
+	})
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -27,12 +27,35 @@ func TestParseUri(t *testing.T) {
 		sip:alice;day=tuesday@atlanta.com
 	*/
 
-	str := "sip:alice@atlanta.com"
 	var uri sip.Uri
-	err := ParseUri(str, &uri)
-	require.Nil(t, err)
-	assert.Equal(t, "alice", uri.User)
-	assert.Equal(t, "atlanta.com", uri.Host)
+	var err error
+	var str string
+
+	testCases := []string{
+		"sip:alice@atlanta.com",
+		"SIP:alice@atlanta.com",
+		"sIp:alice@atlanta.com",
+	}
+	for _, testCase := range testCases {
+		err = ParseUri(testCase, &uri)
+		require.Nil(t, err)
+		assert.Equal(t, "alice", uri.User)
+		assert.Equal(t, "atlanta.com", uri.Host)
+		assert.False(t, uri.Encrypted)
+	}
+
+	testCases = []string{
+		"sips:alice@atlanta.com",
+		"SIPS:alice@atlanta.com",
+		"sIpS:alice@atlanta.com",
+	}
+	for _, testCase := range testCases {
+		err = ParseUri(testCase, &uri)
+		require.Nil(t, err)
+		assert.Equal(t, "alice", uri.User)
+		assert.Equal(t, "atlanta.com", uri.Host)
+		assert.True(t, uri.Encrypted)
+	}
 
 	uri = sip.Uri{}
 	str = "sips:alice@atlanta.com?subject=project%20x&priority=urgent"

--- a/parser/testdata/fuzz/FuzzParseSipMessage/2c025c3ae292cb8b
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/2c025c3ae292cb8b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 0 SIP\r\nV:// ;0=;\r\n")

--- a/parser/testdata/fuzz/FuzzParseSipMessage/60d4a7b56f87dca0
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/60d4a7b56f87dca0
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 0 SIP\r\nV:/\r\n")

--- a/parser/testdata/fuzz/FuzzParseSipMessage/8f6bb03248a83474
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/8f6bb03248a83474
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 0 SIP\r\n00000000000000000000000\r\nm:0;0<\r\n")

--- a/parser/testdata/fuzz/FuzzParseSipMessage/8f997b6062f4880d
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/8f997b6062f4880d
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 0 SIP\r\nT:\r\n")

--- a/parser/testdata/fuzz/FuzzParseSipMessage/92cfc4c51bbcdddf
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/92cfc4c51bbcdddf
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 0 SIP\r\nV://\r\n")

--- a/parser/testdata/fuzz/FuzzParseSipMessage/c7b2fa4d8767b928
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/c7b2fa4d8767b928
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 0 SIP\r\nV:\r\n")

--- a/parser/testdata/fuzz/FuzzParseSipMessage/cfdb2b227e2e14aa
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/cfdb2b227e2e14aa
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 s SIP\r\n0")

--- a/parser/testdata/fuzz/FuzzParseSipMessage/dc4d8cf7ba83620b
+++ b/parser/testdata/fuzz/FuzzParseSipMessage/dc4d8cf7ba83620b
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("0 0 SIP\r\nm:0\"<\r\n")


### PR DESCRIPTION
Fuzzing input received from the network is a best practice for security and correctness. Go 1.18 added native support for fuzzing, see https://go.dev/doc/tutorial/fuzz and https://go.dev/security/fuzz.

The first commit introduces the fuzzer, which can be executed with `go test -fuzz=Fuzz`. For now, this starts off with a trivial SIP message. This can be expanded in the future by adding additional input strings as needed.

The subsequent commits are fixes to various issues found during execution of the fuzzer. Note that each of the files under `parser/testdata/fuzz` automatically become tests that are executed when running `go test`. This ensures that previously discovered crashes are not reintroduced with new changes.

I have executed the fuzzer for a little over two hours after fixing these issues without finding any additional issues.