### PR TITLE
fix: Log only received bytes instead of complete buffer

### DIFF
--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -258,7 +258,7 @@ func (c *TCPConnection) Read(b []byte) (n int, err error) {
 	// Some debug hook. TODO move to proper way
 	n, err = c.Conn.Read(b)
 	if SIPDebug {
-		log.Debug().Msgf("TCP read %s <- %s:\n%s", c.Conn.LocalAddr().String(), c.Conn.RemoteAddr(), string(b))
+		log.Debug().Msgf("TCP read %s <- %s:\n%s", c.Conn.LocalAddr().String(), c.Conn.RemoteAddr(), string(b[:n]))
 	}
 	return n, err
 }
@@ -267,7 +267,7 @@ func (c *TCPConnection) Write(b []byte) (n int, err error) {
 	// Some debug hook. TODO move to proper way
 	n, err = c.Conn.Write(b)
 	if SIPDebug {
-		log.Debug().Msgf("TCP write %s -> %s:\n%s", c.Conn.LocalAddr().String(), c.Conn.RemoteAddr(), string(b))
+		log.Debug().Msgf("TCP write %s -> %s:\n%s", c.Conn.LocalAddr().String(), c.Conn.RemoteAddr(), string(b[:n]))
 	}
 	return n, err
 }


### PR DESCRIPTION
Logging of `string(b)` would log the entire buffer, regardless of message length. If a long message is read followed by a short message, the first part of the buffer would contain the short message, while the remainder of the buffer would be bytes from the long message that has not been overwritten by the short message.

Fix is to only log `string(b[:n])`, that is, the bytes of the buffer that were updated by `Read(b)`.