### PR TITLE
Call TransactionRequest with context

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ Forwarding request is done via client handle:
 ```go
 
 srv.OnInvite(func(req *sip.Request, tx sip.ServerTransaction) {
+    ctx := context.Background()
     req.SetDestination("10.1.2.3") // Change sip.Request destination
     // Start client transaction and relay our request. Add Via and Record-Route header
-    clTx, err := client.TransactionRequest(req, sipgo.ClientRequestAddVia, sipgo.ClientRequestAddRecordRoute)
+    clTx, err := client.TransactionRequest(ctx, req, sipgo.ClientRequestAddVia, sipgo.ClientRequestAddRecordRoute)
     // Send back response
     res := <-cltx.Responses()
     tx.Respond(res)
@@ -132,18 +133,20 @@ srv.OnACK(ackHandler)
 Using client handle allows easy creating and sending request. All you need is this.
 ```go
 req := sip.NewRequest(sip.INVITE, recipient)
-tx, err := client.TransactionRequest(req, opts...) // Send request and get client transaction handle
+ctx := context.Background()
+tx, err := client.TransactionRequest(ctx, req, opts...) // Send request and get client transaction handle
 ```
 Unless you customize transaction request with opts by default `client.TransactionRequest` will build all other
 headers needed to pass correct sip request.
 
 Here is full example:
 ```go
+ctx := context.Background()
 client, _ := sipgo.NewClient(ua) // Creating client handle
 
 // Request is either from server request handler or created
 req.SetDestination("10.1.2.3") // Change sip.Request destination
-tx, err := client.TransactionRequest(req) // Send request and get client transaction handle
+tx, err := client.TransactionRequest(ctx, req) // Send request and get client transaction handle
 
 defer tx.Terminate() // Client Transaction must be terminated for cleanup
 ...
@@ -248,5 +251,3 @@ If you find this project interesting for bigger support or contributing, you can
 [mail](emirfreelance91@gmail.com) 
 
 For bugs features pls create [issue](https://github.com/emiago/sipgo/issues).
-
-

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package sipgo
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -101,10 +102,10 @@ func (c *Client) GetHostname() string {
 // Passing options will override this behavior, that is it is expected
 // that you have request fully built
 // This is useful when using client handle in proxy building as request are already parsed
-func (c *Client) TransactionRequest(req *sip.Request, options ...ClientRequestOption) (sip.ClientTransaction, error) {
+func (c *Client) TransactionRequest(ctx context.Context, req *sip.Request, options ...ClientRequestOption) (sip.ClientTransaction, error) {
 	if len(options) == 0 {
 		clientRequestBuildReq(c, req)
-		return c.tx.Request(req)
+		return c.tx.Request(ctx, req)
 	}
 
 	for _, o := range options {
@@ -112,7 +113,7 @@ func (c *Client) TransactionRequest(req *sip.Request, options ...ClientRequestOp
 			return nil, err
 		}
 	}
-	return c.tx.Request(req)
+	return c.tx.Request(ctx, req)
 }
 
 // WriteRequest sends request directly to transport layer

--- a/example/dialog/main.go
+++ b/example/dialog/main.go
@@ -92,8 +92,10 @@ func (h *Handler) route(req *sip.Request, tx sip.ServerTransaction) {
 		return
 	}
 
+	ctx := context.Background()
+
 	// Start client transaction and relay our request
-	clTx, err := h.c.TransactionRequest(req, sipgo.ClientRequestAddVia, sipgo.ClientRequestAddRecordRoute)
+	clTx, err := h.c.TransactionRequest(ctx, req, sipgo.ClientRequestAddVia, sipgo.ClientRequestAddRecordRoute)
 	if err != nil {
 		log.Error().Err(err).Msg("RequestWithContext  failed")
 		reply(tx, req, 500, "")

--- a/example/proxysip/main.go
+++ b/example/proxysip/main.go
@@ -135,9 +135,11 @@ func setupSipProxy(proxydst string, ip string) *sipgo.Server {
 			return
 		}
 
+		ctx := context.Background()
+
 		req.SetDestination(dst)
 		// Start client transaction and relay our request
-		clTx, err := client.TransactionRequest(req, sipgo.ClientRequestAddVia, sipgo.ClientRequestAddRecordRoute)
+		clTx, err := client.TransactionRequest(ctx, req, sipgo.ClientRequestAddVia, sipgo.ClientRequestAddRecordRoute)
 		if err != nil {
 			log.Error().Err(err).Msg("RequestWithContext  failed")
 			reply(tx, req, 500, "")

--- a/example/register/client/main.go
+++ b/example/register/client/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -64,7 +65,8 @@ func main() {
 	// Send request and parse response
 	// req.SetDestination(*dst)
 	log.Info().Msg(req.StartLine())
-	tx, err := client.TransactionRequest(req)
+	ctx := context.Background()
+	tx, err := client.TransactionRequest(ctx, req)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Fail to create transaction")
 	}
@@ -95,7 +97,8 @@ func main() {
 		newReq := req.Clone()
 		newReq.AppendHeader(sip.NewHeader("Authorization", cred.String()))
 
-		tx, err := client.TransactionRequest(newReq)
+		ctx := context.Background()
+		tx, err := client.TransactionRequest(ctx, newReq)
 		if err != nil {
 			log.Fatal().Err(err).Msg("Fail to create transaction")
 		}

--- a/server_integration_test.go
+++ b/server_integration_test.go
@@ -172,7 +172,7 @@ func TestSimpleCall(t *testing.T) {
 			}
 
 			req, _, _ := createTestInvite(t, proto+":bob@"+tc.serverAddr, tc.transport, client.ip.String())
-			tx, err := client.TransactionRequest(req)
+			tx, err := client.TransactionRequest(ctx, req)
 			require.NoError(t, err)
 
 			res := <-tx.Responses()

--- a/transaction/layer.go
+++ b/transaction/layer.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/emiago/sipgo/sip"
@@ -135,7 +136,7 @@ func (txl *Layer) handleResponse(res *sip.Response) {
 	}
 }
 
-func (txl *Layer) Request(req *sip.Request) (*ClientTx, error) {
+func (txl *Layer) Request(ctx context.Context, req *sip.Request) (*ClientTx, error) {
 	if req.IsAck() {
 		return nil, fmt.Errorf("ACK request must be sent directly through transport")
 	}
@@ -149,7 +150,7 @@ func (txl *Layer) Request(req *sip.Request) (*ClientTx, error) {
 		return nil, fmt.Errorf("transaction %q already exists", key)
 	}
 
-	conn, err := txl.tpl.ClientRequestConnection(req)
+	conn, err := txl.tpl.ClientRequestConnection(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -107,7 +107,10 @@ func (t *TCPTransport) createConnection(ctx context.Context, laddr *net.TCPAddr,
 	addr := raddr.String()
 	t.log.Debug().Str("raddr", addr).Msg("Dialing new connection")
 
-	conn, err := net.DialTCP("tcp", laddr, raddr)
+	d := net.Dialer{
+		LocalAddr: laddr,
+	}
+	conn, err := d.DialContext(ctx, "tcp", raddr.String())
 	if err != nil {
 		return nil, fmt.Errorf("%s dial err=%w", t, err)
 	}

--- a/transport/tcp.go
+++ b/transport/tcp.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -81,7 +82,7 @@ func (t *TCPTransport) GetConnection(addr string) (Connection, error) {
 	return c, nil
 }
 
-func (t *TCPTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
+func (t *TCPTransport) CreateConnection(ctx context.Context, laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
 	// We are letting transport layer to resolve our address
 	// raddr, err := net.ResolveTCPAddr("tcp", addr)
 	// if err != nil {
@@ -99,10 +100,10 @@ func (t *TCPTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.Mess
 		IP:   raddr.IP,
 		Port: raddr.Port,
 	}
-	return t.createConnection(tladdr, traddr, handler)
+	return t.createConnection(ctx, tladdr, traddr, handler)
 }
 
-func (t *TCPTransport) createConnection(laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
+func (t *TCPTransport) createConnection(ctx context.Context, laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
 	addr := raddr.String()
 	t.log.Debug().Str("raddr", addr).Msg("Dialing new connection")
 

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -78,7 +78,7 @@ func (t *TLSTransport) createConnection(ctx context.Context, laddr *net.TCPAddr,
 		Config: t.tlsConf,
 	}
 
-	conn, err := dialer.DialContext(context.TODO(), "tcp", raddr.String())
+	conn, err := dialer.DialContext(ctx, "tcp", raddr.String())
 	if err != nil {
 		return nil, fmt.Errorf("%s dial err=%w", t, err)
 	}

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -41,7 +41,7 @@ func (t *TLSTransport) String() string {
 }
 
 // CreateConnection creates TLS connection for TCP transport
-func (t *TLSTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
+func (t *TLSTransport) CreateConnection(ctx context.Context, laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
 	// raddr, err := net.ResolveTCPAddr("tcp", addr)
 	// if err != nil {
 	// 	return nil, err
@@ -60,10 +60,10 @@ func (t *TLSTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.Mess
 		Port: raddr.Port,
 	}
 
-	return t.createConnection(tladdr, traddr, handler)
+	return t.createConnection(ctx, tladdr, traddr, handler)
 }
 
-func (t *TLSTransport) createConnection(laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
+func (t *TLSTransport) createConnection(ctx context.Context, laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
 	addr := raddr.String()
 	t.log.Debug().Str("raddr", addr).Msg("Dialing new connection")
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"context"
 	"net"
 	"strconv"
 
@@ -36,7 +37,7 @@ const (
 type Transport interface {
 	Network() string
 	GetConnection(addr string) (Connection, error)
-	CreateConnection(laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error)
+	CreateConnection(ctx context.Context, laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error)
 	String() string
 	Close() error
 }

--- a/transport/udp.go
+++ b/transport/udp.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -103,7 +104,7 @@ func (t *UDPTransport) GetConnection(addr string) (Connection, error) {
 }
 
 // CreateConnection will create new connection
-func (t *UDPTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
+func (t *UDPTransport) CreateConnection(ctx context.Context, laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
 	// raddr, err := net.ResolveUDPAddr("udp", addr)
 	// if err != nil {
 	// 	return nil, err

--- a/transport/udp.go
+++ b/transport/udp.go
@@ -123,7 +123,10 @@ func (t *UDPTransport) CreateConnection(ctx context.Context, laddr Addr, raddr A
 		Port: raddr.Port,
 	}
 
-	udpconn, err := net.DialUDP("udp", uladdr, uraddr)
+	d := net.Dialer{
+		LocalAddr: uladdr,
+	}
+	udpconn, err := d.DialContext(ctx, "udp", uraddr.String())
 	if err != nil {
 		return nil, err
 	}

--- a/transport/ws.go
+++ b/transport/ws.go
@@ -211,7 +211,7 @@ func (t *WSTransport) GetConnection(addr string) (Connection, error) {
 	return c, nil
 }
 
-func (t *WSTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
+func (t *WSTransport) CreateConnection(ctx context.Context, laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
 	// raddr, err := net.ResolveTCPAddr("tcp", addr)
 	// if err != nil {
 	// 	return nil, err
@@ -229,10 +229,10 @@ func (t *WSTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.Messa
 		IP:   raddr.IP,
 		Port: raddr.Port,
 	}
-	return t.createConnection(tladdr, traddr, handler)
+	return t.createConnection(ctx, tladdr, traddr, handler)
 }
 
-func (t *WSTransport) createConnection(laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
+func (t *WSTransport) createConnection(ctx context.Context, laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
 	addr := raddr.String()
 	t.log.Debug().Str("raddr", addr).Msg("Dialing new connection")
 

--- a/transport/ws.go
+++ b/transport/ws.go
@@ -236,9 +236,6 @@ func (t *WSTransport) createConnection(ctx context.Context, laddr *net.TCPAddr, 
 	addr := raddr.String()
 	t.log.Debug().Str("raddr", addr).Msg("Dialing new connection")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	// How to define local interface
 	if laddr != nil {
 		log.Error().Str("laddr", laddr.String()).Msg("Dialing with local IP is not supported on ws")

--- a/transport/wss.go
+++ b/transport/wss.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/emiago/sipgo/parser"
 	"github.com/emiago/sipgo/sip"
@@ -67,9 +66,6 @@ func (t *WSSTransport) CreateConnection(ctx context.Context, laddr Addr, raddr A
 func (t *WSSTransport) createConnection(ctx context.Context, laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
 	addr := raddr.String()
 	t.log.Debug().Str("raddr", addr).Msg("Dialing new connection")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	// How to pass local interface
 

--- a/transport/wss.go
+++ b/transport/wss.go
@@ -42,7 +42,7 @@ func (t *WSSTransport) String() string {
 
 // CreateConnection creates WSS connection for TCP transport
 // TODO Make this consisten with TCP
-func (t *WSSTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
+func (t *WSSTransport) CreateConnection(ctx context.Context, laddr Addr, raddr Addr, handler sip.MessageHandler) (Connection, error) {
 	// raddr, err := net.ResolveTCPAddr("tcp", addr)
 	// if err != nil {
 	// 	return nil, err
@@ -61,10 +61,10 @@ func (t *WSSTransport) CreateConnection(laddr Addr, raddr Addr, handler sip.Mess
 		Port: raddr.Port,
 	}
 
-	return t.createConnection(tladdr, traddr, handler)
+	return t.createConnection(ctx, tladdr, traddr, handler)
 }
 
-func (t *WSSTransport) createConnection(laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
+func (t *WSSTransport) createConnection(ctx context.Context, laddr *net.TCPAddr, raddr *net.TCPAddr, handler sip.MessageHandler) (Connection, error) {
 	addr := raddr.String()
 	t.log.Debug().Str("raddr", addr).Msg("Dialing new connection")
 


### PR DESCRIPTION
Subject allows to specify timeouts, e.g.:
```
ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
defer cancel()

tx, err := client.TransactionRequest(ctx, req, opts...)
```
By default, connection establishment may take 2-3 minutes depending on the transport.

https://pkg.go.dev/net#Dialer

> // With or without a timeout, the operating system may impose
> // its own earlier timeout. For instance, TCP timeouts are
> // often around 3 minutes.
> Timeout [time](https://pkg.go.dev/time).[Duration](https://pkg.go.dev/time#Duration)