### PR TITLE
Correctly reload dialog state

### DIFF
--- a/dialog_server.go
+++ b/dialog_server.go
@@ -208,6 +208,7 @@ func (s *DialogServerSession) Bye(ctx context.Context) error {
 	// until it has received an ACK for its 2xx response or until the server
 	// transaction times out.
 	for {
+		state = s.state.Load()
 		if sip.DialogState(state) < sip.DialogStateConfirmed {
 			select {
 			case <-s.inviteTx.Done():


### PR DESCRIPTION
Currently the dialog state is loaded once and checked in the loop. This change properly reloads the current state on each loop iteration.