### PR TITLE
fix: use record route header in bye

### DIFF
--- a/client.go
+++ b/client.go
@@ -125,6 +125,7 @@ func (c *Client) TransactionRequest(ctx context.Context, req *sip.Request, optio
 			// WriteRequest for ex ACK will not increase and this is wanted behavior
 			// This will be a problem if we allow ACK to be passed as transaction request
 			cseq.SeqNo++
+			cseq.MethodName = req.Method
 		}
 
 		clientRequestBuildReq(c, req)

--- a/dialog_server.go
+++ b/dialog_server.go
@@ -250,6 +250,23 @@ func (s *DialogServerSession) Bye(ctx context.Context) error {
 	bye.AppendHeader(newTo)
 	bye.AppendHeader(callid)
 
+	recordRoute := req.RecordRoute()
+	if recordRoute != nil {
+		if recordRoute.Address.UriParams.Has("lr") {
+			bye.AppendHeader(&sip.RouteHeader{Address: recordRoute.Address})
+		} else {
+			/* TODO
+			   If the route set is not empty, and its first URI does not contain the
+			   lr parameter, the UAC MUST place the first URI from the route set
+			   into the Request-URI, stripping any parameters that are not allowed
+			   in a Request-URI.  The UAC MUST add a Route header field containing
+			   the remainder of the route set values in order, including all
+			   parameters.  The UAC MUST then place the remote target URI into the
+			   Route header field as the last value.
+			*/
+		}
+	}
+
 	callidHDR := bye.CallID()
 	byeID := sip.MakeDialogID(callidHDR.Value(), newFrom.Params["tag"], newTo.Params["tag"])
 	if s.ID != byeID {


### PR DESCRIPTION
There are steps on how to form a request when record-route is present in the RFC: https://www.rfc-editor.org/rfc/rfc3261.html#section-12.2.1.1

> If the route set is empty, the UAC MUST place the remote target URI
>    into the Request-URI.  The UAC MUST NOT add a Route header field to
>    the request.

We are handling the above case well.

>    If the route set is not empty, and the first URI in the route set
>    contains the lr parameter (see [Section 19.1.1](https://www.rfc-editor.org/rfc/rfc3261.html#section-19.1.1)), the UAC MUST place
>    the remote target URI into the Request-URI and MUST include a Route
>    header field containing the route set values in order, including all
>    parameters.


>    If the route set is not empty, and its first URI does not contain the
>    lr parameter, the UAC MUST place the first URI from the route set
>    into the Request-URI, stripping any parameters that are not allowed
>    in a Request-URI.  The UAC MUST add a Route header field containing
>    the remainder of the route set values in order, including all
>    parameters.  The UAC MUST then place the remote target URI into the
>    Route header field as the last value.


We also need to send ALL these values as Route header, not just one, not implemented in this PR.