### PR TITLE
fix: use invite response route headers for bye

### DIFF
--- a/sip/request.go
+++ b/sip/request.go
@@ -347,10 +347,10 @@ func NewByeRequestUAC(inviteRequest *Request, inviteResponse *Response, body []b
 	if len(inviteRequest.GetHeaders("Route")) > 0 {
 		CopyHeaders("Route", inviteRequest, byeRequest)
 	} else {
-		hdrs := inviteResponse.GetHeaders("Record-Route")
-		for i := len(hdrs) - 1; i >= 0; i-- {
-			h := hdrs[i].headerClone()
-			byeRequest.AppendHeader(h)
+		recordRoute := inviteResponse.RecordRoute()
+		for recordRoute != nil {
+			byeRequest.AppendHeader(&RouteHeader{Address: recordRoute.Address})
+			recordRoute = recordRoute.Next
 		}
 	}
 


### PR DESCRIPTION
`Record-Route` header  from invite response  should be converted to `Route` header in the bye request.