### PR TITLE
set min to 1.20 for win 7 compliant

### DIFF
--- a/example/proxysip/docker/proxy/Dockerfile
+++ b/example/proxysip/docker/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17
+FROM golang:1.20
 
 WORKDIR /go/src/app
 COPY . .

--- a/example/proxysip/go.mod
+++ b/example/proxysip/go.mod
@@ -1,6 +1,6 @@
 module github.com/emiago/sipgo/example/proxysip
 
-go 1.21.1
+go 1.20
 
 replace github.com/emiago/sipgo => ../../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/emiago/sipgo
 
-go 1.21
+go 1.20
 
 require (
 	github.com/gobwas/ws v1.2.1


### PR DESCRIPTION
we use sipgo in a project which deploy under windows 7, the go 1.20 is last version support windows 7, so please lower one version for win 7 compliant， sipgo don't use new feature in newer version as far as i know.
