### PR TITLE
fix: honor lr in record route for dialog clients

### DIFF
--- a/dialog_client.go
+++ b/dialog_client.go
@@ -238,7 +238,13 @@ func (s *DialogClientSession) TransactionRequest(ctx context.Context, req *sip.R
 		}
 
 		if rr := s.InviteResponse.RecordRoute(); rr != nil {
-			req.SetDestination(rr.Address.HostPort())
+			if rr.Address.UriParams.Has("lr") {
+				req.AppendHeader(&sip.RouteHeader{
+					Address: rr.Address,
+				})
+			} else {
+				req.SetDestination(rr.Address.HostPort())
+			}
 		}
 	}
 


### PR DESCRIPTION
The LR in a record route means that the route should be added to the client request. This fix honors the specification.