### PR TITLE
fix: ACK request does not convert the Record-Route headers into Route headers

### DIFF
--- a/sip/request.go
+++ b/sip/request.go
@@ -235,8 +235,8 @@ func NewAckRequest(inviteRequest *Request, inviteResponse *Response, body []byte
 		// https://datatracker.ietf.org/doc/html/rfc2543#section-6.29
 		hdrs := inviteResponse.GetHeaders("Record-Route")
 		for i := len(hdrs) - 1; i >= 0; i-- {
-			h := hdrs[i].headerClone()
-			ackRequest.AppendHeader(h)
+			recordRoute := hdrs[i]
+			ackRequest.AppendHeader(NewHeader("Route", recordRoute.Value()))
 		}
 	}
 


### PR DESCRIPTION
UAC ACK request should convert the Record-Route headers into Route headers.

https://datatracker.ietf.org/doc/html/rfc2543#section-6.29

> The calling user agent client copies the Record-Route header into a
   Route header field of subsequent requests within the same call leg,
   reversing the order of requests