### PR TITLE
bug: uri.HostPort() unset port

### DIFF
--- a/sip/uri.go
+++ b/sip/uri.go
@@ -131,6 +131,9 @@ func (uri *Uri) Addr() string {
 
 // HostPort represents host:port part
 func (uri *Uri) HostPort() string {
+	if uri.Port == 0 {
+		return uri.Host
+	}
 	p := strconv.Itoa(uri.Port)
 	return uri.Host + ":" + p
 }

--- a/sip/uri.go
+++ b/sip/uri.go
@@ -132,8 +132,9 @@ func (uri *Uri) Addr() string {
 // HostPort represents host:port part
 func (uri *Uri) HostPort() string {
 	if uri.Port == 0 {
-		return uri.Host
+		return uri.Host + ":5060"
 	}
+	
 	p := strconv.Itoa(uri.Port)
 	return uri.Host + ":" + p
 }


### PR DESCRIPTION
Port zero returned by this function caused some internal bugs, for example when using DialogClientSession's Ack() function with Record-Route header specified in the response.

This PR should fix this.
