### PR TITLE
export SetIP function

### DIFF
--- a/ua.go
+++ b/ua.go
@@ -85,7 +85,7 @@ func NewUA(options ...UserAgentOption) (*UserAgent, error) {
 		if err != nil {
 			return nil, err
 		}
-		if err := ua.setIP(v); err != nil {
+		if err := ua.SetIP(v); err != nil {
 			return nil, err
 		}
 	}
@@ -104,7 +104,7 @@ func (ua *UserAgent) Close() error {
 }
 
 // Listen adds listener for serve
-func (ua *UserAgent) setIP(ip net.IP) (err error) {
+func (ua *UserAgent) SetIP(ip net.IP) (err error) {
 	ua.ip = ip
 	return err
 }


### PR DESCRIPTION
On my cloud server, the automatically obtained IP is a local LAN IP rather than a public IP, causing message delivery failures to cloud server form devices. I need a method to expose this setIP functionality for manual IP configuration.