### PR TITLE
Added tel: URI support

### DIFF
--- a/sip/parse_uri.go
+++ b/sip/parse_uri.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unicode"
 )
 
 type uriFSM func(uri *Uri, s string) (uriFSM, string, error)
@@ -48,10 +47,6 @@ func uriStateScheme(uri *Uri, s string) (uriFSM, string, error) {
 
 	uri.Scheme = strings.ToLower(s[:colInd])
 	s = s[colInd+1:]
-
-	if err := validateScheme(uri.Scheme); err != nil {
-		return nil, "", err
-	}
 
 	if uri.Scheme == "tel" {
 		return uriTelNumber, s, nil
@@ -177,24 +172,6 @@ func uriStateHeaders(uri *Uri, s string) (uriFSM, string, error) {
 	uri.Headers = NewParams()
 	_, err = UnmarshalParams(s, '&', 0, uri.Headers)
 	return nil, s, err
-}
-
-// validateScheme performs basic scheme validation to prevent cases where port delimited 
-// (or other naturally occuring colon) is mistakenly used as a scheme delimiter. 
-// This is NOT a fool-proof validation and URIs may still be incorrectly parsed 
-// unless more parsing validation effort is made.
-//
-// scheme        = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
-func validateScheme(scheme string) error {
-	if len(scheme) == 0 {
-		return errors.New("no scheme found")
-	}
-	for _, c := range scheme {
-		if !unicode.IsLetter(c) && !unicode.IsDigit(c) && c != '+' && c != '-' && c != '.' {
-			return fmt.Errorf("invalid scheme: %q is not allowed", c)
-		}
-	}
-	return nil
 }
 
 func uriTelNumber(uri *Uri, s string) (uriFSM, string, error) {

--- a/sip/parse_uri_test.go
+++ b/sip/parse_uri_test.go
@@ -82,18 +82,19 @@ func TestParseUri(t *testing.T) {
 		}
 	})
 
-	t.Run("sip scheme", func(t *testing.T) {
-		// No scheme is not allowed
-		// URI relative references are not supported yet
-		testCases := []string{
-			"example.com;foo=bar",
-			"alice@localhost:5060",
-			"bad_scheme://example.com",
+	t.Run("bad/missing sip scheme", func(t *testing.T) {
+		// URI must always have a scheme. URI relative references are not supported yet
+		// Supplying URIs without a scheme will lead to incorrectly parsed URIs
+		testCases := [][]string{
+			[]string{"example.com:5060;foo=bar", "example.com"},
+			[]string{"alice@localhost:5060", "alice@localhost"},
+			[]string{"bad_scheme://example.com", "bad_scheme"}, // underscores are not allowed in scheme
 		}
 		for _, testCase := range testCases {
 			uri = Uri{}
-			err = ParseUri(testCase, &uri)
-			require.Error(t, err)
+			err = ParseUri(testCase[0], &uri)
+			require.NoError(t, err)
+			assert.Equal(t, testCase[1], uri.Scheme)
 		}
 	})
 

--- a/sip/parse_uri_test.go
+++ b/sip/parse_uri_test.go
@@ -134,6 +134,27 @@ func TestParseUri(t *testing.T) {
 		assert.Equal(t, "z9hG4bKPj6c65c5d9-b6d0-4a30-9383-1f9b42f97de9", branch)
 
 	})
+
+	t.Run("tel scheme", func(t *testing.T) {
+		testCases := [][]string{
+			[]string{"tel:+1-(201) 555 0123", "+1-(201) 555 0123", ""},
+			[]string{"tel:7042;phone-context=example.com", "7042", "phone-context", "example.com"},
+		}
+		for _, testCase := range testCases {
+			err = ParseUri(testCase[0], &uri)
+			require.NoError(t, err)
+			assert.Equal(t, SCHEME_TEL, uri.Scheme)
+			assert.Equal(t, testCase[1], uri.Telephone)
+			if testCase[2] != "" {
+				assert.Less(t, 0, uri.UriParams.Length())
+				val, found := uri.UriParams.Get(testCase[2])
+				assert.Equal(t, true, found)
+				assert.Equal(t, testCase[3], val)
+				assert.Equal(t, testCase[0], uri.String())
+			}
+			assert.False(t, uri.Encrypted)
+		}
+	})
 }
 
 func TestParseUriBad(t *testing.T) {

--- a/sip/uri.go
+++ b/sip/uri.go
@@ -67,7 +67,13 @@ func (uri *Uri) String() string {
 // StringWrite writes uri string to buffer
 func (uri *Uri) StringWrite(buffer io.StringWriter) {
 	// Compulsory protocol identifier.
-	buffer.WriteString(string(uri.Scheme))
+	if uri.Scheme != "" {
+		buffer.WriteString(string(uri.Scheme))
+	} else {
+		// In order to keep supporting invalid URI format without a scheme
+		// assuming sip: scheme by default
+		buffer.WriteString(string(SCHEME_SIP))
+	}
 	buffer.WriteString(":")
 
 	if uri.Scheme == SCHEME_TEL {


### PR DESCRIPTION
This PR adds simplified support for the [tel: URIs](https://datatracker.ietf.org/doc/html/rfc3966#section-3).

No validation on the telephone number is performed.

Attempted to preserve existing URI type without diving into different interfaces for different URI types.