### PR TITLE
Prioritize IPv4 during DNS resolution

### DIFF
--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -468,6 +468,12 @@ func (l *TransportLayer) resolveAddrIP(ctx context.Context, hostname string, add
 		return fmt.Errorf("lookup ip addr did not return any ip addr")
 	}
 
+	for _, ip := range ips {
+		if len(ip.IP) == net.IPv4len {
+			addr.IP = ip.IP
+			return nil
+		}
+	}
 	addr.IP = ips[0].IP
 	return nil
 }


### PR DESCRIPTION
This modification prioritizes IPv4 address during DNS resolution.
It solves issues when IPv6 is returned, but not routable. 
See also  https://github.com/emiago/sipgo/issues/119. 