### PR TITLE
UAS Dialog BYE request uses wrong transport

### DIFF
--- a/dialog_server.go
+++ b/dialog_server.go
@@ -449,6 +449,7 @@ func (s *DialogServerSession) Bye(ctx context.Context) error {
 	cont := req.Contact()
 	// TODO Contact is has no resolvable address or TCP is used, then address should be source due TO NAT
 	bye := sip.NewRequest(sip.BYE, cont.Address)
+	bye.SetTransport(req.Transport())
 
 	tx, err := s.TransactionRequest(ctx, bye)
 	if err != nil {


### PR DESCRIPTION
In the docs example :

```golang
ua, _ := sipgo.NewUA() // Build user agent
srv, _ := sipgo.NewServer(ua) // Creating server handle
client, _ := sipgo.NewClient(ua) // Creating client handle

uasContact := sip.ContactHeader{
    Address: sip.Uri{User: "test", Host: "127.0.0.200", Port: 5099},
}
dialogSrv := sipgo.NewDialogServer(client, uasContact)

srv.OnInvite(func(req *sip.Request, tx sip.ServerTransaction) {
    dlg, err := dialogSrv.ReadInvite(req, tx)
    // handle error
    dlg.Respond(sip.StatusTrying, "Trying", nil)
    dlg.Respond(sip.StatusOK, "OK", nil)
    
    // send 200 with sdp
    dlg.RespondSDP(answer)
    
    // do media or not after a while if you decide to Hangup
    dlg.Bye(ctx) // this will use UDP even if the INVITE used TCP
    
    // Instead Done also dlg.State() can be used for granular state checking
    <-dlg.Context().Done()
})

srv.OnAck(func(req *sip.Request, tx sip.ServerTransaction) {
    dialogSrv.ReadAck(req, tx)
})

srv.OnBye(func(req *sip.Request, tx sip.ServerTransaction) {
    dialogSrv.ReadBye(req, tx)
})
```

The transport layer pulls the transport to use from the newly created bye request anyway ?