### PR TITLE
Properly use receiver for header parsers

### DIFF
--- a/sip/parse_header.go
+++ b/sip/parse_header.go
@@ -81,7 +81,7 @@ func (headersParser mapHeadersParser) parseMsgHeader(msg Message, headerText str
 	lowerFieldName := HeaderToLower(fieldName)
 	fieldText := strings.TrimSpace(headerText[colonIdx+1:])
 
-	headerParser, ok := headersParsers[lowerFieldName]
+	headerParser, ok := headersParser[lowerFieldName]
 	if !ok {
 		// We have no registered parser for this header type,
 		// so we encapsulate the header data in a GenericHeader struct.


### PR DESCRIPTION
Because of the typo, currently the parser always uses global map of header parsers. This fix ensures that it uses the receiver map, which could be modified by the user.