### PR TITLE
Return pointer from NewConnectionPool

### DIFF
--- a/sip/transport_connection_pool.go
+++ b/sip/transport_connection_pool.go
@@ -38,8 +38,8 @@ type ConnectionPool struct {
 	m map[string]Connection
 }
 
-func NewConnectionPool() ConnectionPool {
-	return ConnectionPool{
+func NewConnectionPool() *ConnectionPool {
+	return &ConnectionPool{
 		m: make(map[string]Connection),
 	}
 }

--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -20,7 +20,7 @@ type transportTCP struct {
 	parser    *Parser
 	log       zerolog.Logger
 
-	pool ConnectionPool
+	pool *ConnectionPool
 }
 
 func newTCPTransport(par *Parser) *transportTCP {

--- a/sip/transport_udp.go
+++ b/sip/transport_udp.go
@@ -26,7 +26,7 @@ type transportUDP struct {
 	// listener *net.UDPConn
 	parser *Parser
 
-	pool ConnectionPool
+	pool *ConnectionPool
 	log  zerolog.Logger
 }
 

--- a/sip/transport_ws.go
+++ b/sip/transport_ws.go
@@ -30,7 +30,7 @@ type transportWS struct {
 	log       zerolog.Logger
 	transport string
 
-	pool   ConnectionPool
+	pool   *ConnectionPool
 	dialer ws.Dialer
 }
 


### PR DESCRIPTION
Returning by value triggers static analyzers that detect that the mutex inside the connection pool is copied.