### PR TITLE
Do not use buffer pool for ParseSIP

### DIFF
--- a/sip/parser.go
+++ b/sip/parser.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -30,15 +29,6 @@ var (
 	ErrParseReadBodyIncomplete = errors.New("reading body incomplete")
 	ErrParseMoreMessages       = errors.New("Stream has more message")
 )
-
-var bufReader = sync.Pool{
-	New: func() interface{} {
-		// The Pool's New function should generally only return pointer
-		// types, since a pointer can be put into the return interface
-		// value without an allocation:
-		return new(bytes.Buffer)
-	},
-}
 
 func ParseMessage(msgData []byte) (Message, error) {
 	parser := NewParser()
@@ -90,10 +80,7 @@ func WithHeadersParsers(m map[string]HeaderParser) ParserOption {
 
 // ParseSIP converts data to sip message. Buffer must contain full sip message
 func (p *Parser) ParseSIP(data []byte) (msg Message, err error) {
-	reader := bufReader.Get().(*bytes.Buffer)
-	defer bufReader.Put(reader)
-	reader.Reset()
-	reader.Write(data)
+	reader := bytes.NewBuffer(data)
 
 	startLine, err := nextLine(reader)
 	if err != nil {


### PR DESCRIPTION
This change removes the use of `sync.Pool` containing `bytes.Buffer` from the `Parser.ParseSIP`.

Use of buffer pool is not beneficial here, because function receives a `[]byte` already containing the full message. Thus, buffer write can be replaced with `bytes.NewBuffer(data)`.

Benchmark shows a tiny performance gain and reduced total allocations:
```
                               │   sec/op    │   sec/op     vs base               │
Parser/SingleRoutine-16          2.773µ ± 0%   2.670µ ± 1%  -3.73% (p=0.000 n=10)
Parser/Paralel-16                13.98µ ± 4%   13.52µ ± 3%  -3.23% (p=0.019 n=10)


                               │      B/op      │     B/op      vs base                 │
Parser/SingleRoutine-16          2.634Ki ± 0%     2.633Ki ± 0%  -0.04% (p=0.000 n=10)
Parser/Paralel-16                2.824Ki ± 0%     2.639Ki ± 0%  -6.57% (p=0.000 n=10)
```


<details><summary>Full benchmark result</summary>

```
                               │   old.txt   │              new.txt               │
                               │   sec/op    │   sec/op     vs base               │
ParseAddress-16                  585.4n ± 3%   598.3n ± 3%  +2.21% (p=0.023 n=10)
ParserStream/NoChunks-16         2.510µ ± 1%   2.474µ ± 1%  -1.45% (p=0.000 n=10)
ParserStream/SingleRoutine-16    2.627µ ± 0%   2.580µ ± 0%  -1.77% (p=0.000 n=10)
ParserStream/Paralel-16          13.05µ ± 6%   12.94µ ± 6%       ~ (p=0.796 n=10)
Parser/SingleRoutine-16          2.773µ ± 0%   2.670µ ± 1%  -3.73% (p=0.000 n=10)
Parser/Paralel-16                13.98µ ± 4%   13.52µ ± 3%  -3.23% (p=0.019 n=10)
ParseStartLine-16                250.6n ± 9%   238.8n ± 1%  -4.71% (p=0.000 n=10)
ParserNoData/New-16              2.359µ ± 1%   2.294µ ± 1%  -2.78% (p=0.000 n=10)

                               │    old.txt     │                new.txt                │
                               │      B/op      │     B/op      vs base                 │
ParseAddress-16                    384.0 ± 0%       384.0 ± 0%       ~ (p=1.000 n=10) ¹
ParserStream/NoChunks-16         2.446Ki ± 0%     2.446Ki ± 0%       ~ (p=1.000 n=10) ¹
ParserStream/SingleRoutine-16    2.501Ki ± 0%     2.501Ki ± 0%       ~ (p=1.000 n=10) ¹
ParserStream/Paralel-16          2.680Ki ± 0%     2.679Ki ± 0%       ~ (p=0.171 n=10)
Parser/SingleRoutine-16          2.634Ki ± 0%     2.633Ki ± 0%  -0.04% (p=0.000 n=10)
Parser/Paralel-16                2.824Ki ± 0%     2.639Ki ± 0%  -6.57% (p=0.000 n=10)
ParseStartLine-16                  464.0 ± 0%       464.0 ± 0%       ~ (p=1.000 n=10) ¹
ParserNoData/New-16              2.505Ki ± 0%     2.504Ki ± 0%  -0.04% (p=0.000 n=10)

                               │   old.txt    │               new.txt               │
                               │  allocs/op   │ allocs/op   vs base                 │
ParseAddress-16                  4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
ParserStream/NoChunks-16         37.00 ± 0%     37.00 ± 0%       ~ (p=1.000 n=10) ¹
ParserStream/SingleRoutine-16    39.00 ± 0%     39.00 ± 0%       ~ (p=1.000 n=10) ¹
ParserStream/Paralel-16          39.00 ± 0%     39.00 ± 0%       ~ (p=1.000 n=10) ¹
Parser/SingleRoutine-16          37.00 ± 0%     37.00 ± 0%       ~ (p=1.000 n=10) ¹
Parser/Paralel-16                37.00 ± 0%     37.00 ± 0%       ~ (p=1.000 n=10) ¹
ParseStartLine-16                3.000 ± 0%     3.000 ± 0%       ~ (p=1.000 n=10) ¹
ParserNoData/New-16              35.00 ± 0%     35.00 ± 0%       ~ (p=1.000 n=10) ¹
```

</details> 