### PR TITLE
Remove deprecated rand.Seed

### DIFF
--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net"
 	"sync"
 	"time"
@@ -20,10 +19,6 @@ var (
 	// Errors
 	ErrTransportNotSuported = errors.New("protocol not supported")
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // TransportLayer implementation.
 type TransportLayer struct {
@@ -71,7 +66,7 @@ func NewTransportLayer(
 	if tlsConfig == nil {
 		// Use empty tls config
 		tlsConfig = &tlsEmptyConf
-	}	
+	}
 	// TODO consider this transports are configurable from outside
 	// Make some default transports available.
 	l.udp = newUDPTransport(sipparser)

--- a/sip/utils.go
+++ b/sip/utils.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"time"
 )
 
 const (
@@ -19,10 +18,6 @@ const (
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
 	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 // https://github.com/kpbird/golang_random_string
 func RandString(n int) string {


### PR DESCRIPTION
Since Go 1.20, use of `rand.Seed` is [deprecated](https://pkg.go.dev/math/rand#Seed). Package `math/rand` randomizes the seed by default.