### PR TITLE
Proposal for fixing ACK destination on INVITE

### DIFF
--- a/dialog_client.go
+++ b/dialog_client.go
@@ -144,13 +144,6 @@ func (s *DialogClientSession) TransactionRequest(ctx context.Context, req *sip.R
 }
 
 func (s *DialogClientSession) WriteRequest(req *sip.Request) error {
-	// Check Record-Route Header
-	if s.InviteResponse != nil {
-		// Record Route handling
-		if rr := s.InviteResponse.RecordRoute(); rr != nil {
-			req.SetDestination(rr.Address.HostPort())
-		}
-	}
 	return s.ua.Client.WriteRequest(req)
 }
 


### PR DESCRIPTION
* ACK is in some scenarios sent to the wrong destination. Fixed by first reversing record routes and then using the first entry as destination.
* In our tests we saw this causing calls using UDP to fail, TCP worked.
* Example of failure before change: https://app.dev.sipfront.com/kiosk/bf6c0b85-c1bd-497f-b8b3-71772e935f37/94626162-9af0-11ef-adf3-b36e6b5447b2
* Example of behaviour after change: https://app.dev.sipfront.com/kiosk/bf6c0b85-c1bd-497f-b8b3-71772e935f37/f5dfd402-9aef-11ef-9cfb-f8b61b0dd1db

See the SIP traces - before the ACK was sent to 127.0.0.1, causing the call to fail.