### PR TITLE
Add support for SIP SRV record lookup

### DIFF
--- a/sip/headers.go
+++ b/sip/headers.go
@@ -657,12 +657,12 @@ func (h *ContactHeader) valueWrite(buffer io.StringWriter) {
 
 	buffer.WriteString("<")
 	h.Address.StringWrite(buffer)
-	buffer.WriteString(">")
 
 	if (h.Params != nil) && (h.Params.Length() > 0) {
 		buffer.WriteString(";")
 		h.Params.ToStringWrite(';', buffer)
 	}
+	buffer.WriteString(">")
 }
 
 // Copy the header.

--- a/sip/response.go
+++ b/sip/response.go
@@ -75,11 +75,11 @@ func (res *Response) String() string {
 
 func (res *Response) StringWrite(buffer io.StringWriter) {
 	res.StartLineWrite(buffer)
-	buffer.WriteString("\r\n")
+	//	buffer.WriteString("\r\n")
 	// Write the headers.
 	res.headers.StringWrite(buffer)
 	// Empty line
-	buffer.WriteString("\r\n")
+	//	buffer.WriteString("\r\n")
 	// message body
 	if res.body != nil {
 		// buffer.WriteString("\r\n")
@@ -190,12 +190,7 @@ func (res *Response) Destination() string {
 }
 
 // RFC 3261 - 8.2.6
-func NewResponseFromRequest(
-	req *Request,
-	statusCode StatusCode,
-	reason string,
-	body []byte,
-) *Response {
+func NewResponseFromRequest(req *Request, statusCode StatusCode, reason string, body []byte) *Response {
 	res := NewResponse(
 		statusCode,
 		reason,


### PR DESCRIPTION
Add support for looking up SIP SRV records when they exist to correctly route SIP traffic.

_sip._tcp.<host> for SIP
_sips._tcp.<host> for SIP

According to RFC3263