### PR TITLE
Add Header structs and parsers for Refer-to and Referred-by

### DIFF
--- a/sip/headers.go
+++ b/sip/headers.go
@@ -96,10 +96,6 @@ func (hs *headers) setHeaderRef(header Header) {
 		hs.contentType = m
 	case *MaxForwardsHeader:
 		hs.maxForwards = m
-	case *ReferToHeader:
-		hs.referTo = m
-	case *ReferredByHeader:
-		hs.referredBy = m
 	}
 }
 
@@ -127,10 +123,6 @@ func (hs *headers) unref(header Header) {
 		hs.contentType = nil
 	case *MaxForwardsHeader:
 		hs.maxForwards = nil
-	case *ReferToHeader:
-		hs.referTo = nil
-	case *ReferredByHeader:
-		hs.referredBy = nil
 	}
 }
 

--- a/sip/headers.go
+++ b/sip/headers.go
@@ -410,25 +410,22 @@ func (hs *headers) RecordRoute() *RecordRouteHeader {
 }
 
 // ReferTo returns underlying Refer-To parsed header or nil if not exists
-func (hs *headers) ReferTo() *ReferToHeader {
-	if hs.referTo == nil {
-		h := &ReferToHeader{}
-		if parseHeaderLazy(hs, parseReferToHeader, []string{"refer-to"}, h) {
-			hs.referTo = h
-		}
+func (hs *headers) ReferTo() (ret *ReferToHeader, ok bool) {
+	h := &ReferToHeader{}
+	if parseHeaderLazy(hs, parseReferToHeader, []string{"refer-to"}, h) {
+		hs.referTo = h
+		return h, true
 	}
-	return hs.referTo
+	return nil, false
 }
 
 // ReferredBy returns underlying Referred-By parsed header or nil if not exists
-func (hs *headers) ReferredBy() *ReferredByHeader {
-	if hs.referredBy == nil {
-		h := &ReferredByHeader{}
-		if parseHeaderLazy(hs, parseReferredByHeader, []string{"referred-by"}, h) {
-			hs.referredBy = h
-		}
+func (hs *headers) ParseReferredBy() (ret *ReferredByHeader, ok bool) {
+	h := &ReferredByHeader{}
+	if parseHeaderLazy(hs, parseReferredByHeader, []string{"referred-by"}, h) {
+		return h, true
 	}
-	return hs.referredBy
+	return nil, false
 }
 
 // NewHeader creates generic type of header

--- a/sip/headers.go
+++ b/sip/headers.go
@@ -1032,7 +1032,7 @@ func (h *RecordRouteHeader) Clone() *RecordRouteHeader {
 
 // ReferToHeader is Refer-To header representation.
 type ReferToHeader struct {
-	Uri Uri
+	Address Uri
 }
 
 func (h *ReferToHeader) Name() string { return "Refer-To" }
@@ -1045,7 +1045,7 @@ func (h *ReferToHeader) Value() string {
 
 func (h *ReferToHeader) ValueStringWrite(buffer io.StringWriter) {
 	buffer.WriteString("<")
-	h.Uri.StringWrite(buffer)
+	h.Address.StringWrite(buffer)
 	buffer.WriteString(">")
 }
 
@@ -1067,9 +1067,14 @@ func (h *ReferToHeader) headerClone() Header {
 
 func (h *ReferToHeader) Clone() *ReferToHeader {
 	newTarget := &ReferToHeader{
-		Uri: *h.Uri.Clone(),
+		Address: *h.Address.Clone(),
 	}
 	return newTarget
+}
+
+// ReferredByHeader is Referred-By header representation.
+type ReferredByHeader struct {
+	Uri Uri
 }
 
 // Copy all headers of one type from one message to another.

--- a/sip/headers.go
+++ b/sip/headers.go
@@ -410,22 +410,21 @@ func (hs *headers) RecordRoute() *RecordRouteHeader {
 }
 
 // ReferTo returns underlying Refer-To parsed header or nil if not exists
-func (hs *headers) ParseReferTo() (ret *ReferToHeader, ok bool) {
+func (hs *headers) ParseReferTo() *ReferToHeader {
 	h := &ReferToHeader{}
 	if parseHeaderLazy(hs, parseReferToHeader, []string{"refer-to"}, h) {
-		hs.referTo = h
-		return h, true
+		return h
 	}
-	return nil, false
+	return nil
 }
 
 // ReferredBy returns underlying Referred-By parsed header or nil if not exists
-func (hs *headers) ParseReferredBy() (ret *ReferredByHeader, ok bool) {
+func (hs *headers) ParseReferredBy() *ReferredByHeader {
 	h := &ReferredByHeader{}
 	if parseHeaderLazy(hs, parseReferredByHeader, []string{"referred-by"}, h) {
-		return h, true
+		return h
 	}
-	return nil, false
+	return nil
 }
 
 // NewHeader creates generic type of header

--- a/sip/headers.go
+++ b/sip/headers.go
@@ -410,7 +410,7 @@ func (hs *headers) RecordRoute() *RecordRouteHeader {
 }
 
 // ReferTo returns underlying Refer-To parsed header or nil if not exists
-func (hs *headers) ReferTo() (ret *ReferToHeader, ok bool) {
+func (hs *headers) ParseReferTo() (ret *ReferToHeader, ok bool) {
 	h := &ReferToHeader{}
 	if parseHeaderLazy(hs, parseReferToHeader, []string{"refer-to"}, h) {
 		hs.referTo = h

--- a/sip/parse_address.go
+++ b/sip/parse_address.go
@@ -286,7 +286,7 @@ func headerParserReferTo(headerName string, headerText string) (header Header, e
 }
 
 func parseReferToHeader(headerText string, h *ReferToHeader) error {
-	return parseRouteAddress(headerText, &h.Uri)
+	return parseRouteAddress(headerText, &h.Address)
 }
 
 func parseRouteAddress(headerText string, address *Uri) (err error) {

--- a/sip/parse_address.go
+++ b/sip/parse_address.go
@@ -280,6 +280,15 @@ func parseRecordRouteHeader(headerText string, h *RecordRouteHeader) error {
 	return parseRouteAddress(headerText, &h.Address)
 }
 
+func headerParserReferTo(headerName string, headerText string) (header Header, err error) {
+	h := ReferToHeader{}
+	return &h, parseReferToHeader(headerText, &h)
+}
+
+func parseReferToHeader(headerText string, h *ReferToHeader) error {
+	return parseRouteAddress(headerText, &h.Uri)
+}
+
 func parseRouteAddress(headerText string, address *Uri) (err error) {
 	inBrackets := false
 	inQuotes := false

--- a/sip/parse_address.go
+++ b/sip/parse_address.go
@@ -286,7 +286,32 @@ func headerParserReferTo(headerName string, headerText string) (header Header, e
 }
 
 func parseReferToHeader(headerText string, h *ReferToHeader) error {
-	return parseRouteAddress(headerText, &h.Address)
+	return parseRouteAddress(headerText, &h.Address) // calling parseRouteAddress because the structure is same
+}
+
+func headerParserReferredBy(headerName string, headerText string) (header Header, err error) {
+	h := &ReferredByHeader{}
+	return h, parseReferredByHeader(headerText, h)
+}
+
+func parseReferredByHeader(headerText string, h *ReferredByHeader) error {
+	var err error
+
+	h.Params = NewParams()
+	h.DisplayName, err = ParseAddressValue(headerText, &h.Address, h.Params)
+	if err != nil {
+		return err
+	}
+
+	if h.Address.Wildcard {
+		// The Wildcard '*' URI is only permitted in Contact headers.
+		err = fmt.Errorf(
+			"wildcard uri not permitted in to: header: %s",
+			headerText,
+		)
+		return err
+	}
+	return nil
 }
 
 func parseRouteAddress(headerText string, address *Uri) (err error) {

--- a/sip/parse_header.go
+++ b/sip/parse_header.go
@@ -57,6 +57,7 @@ var headersParsers = mapHeadersParser{
 	"route":          headerParserRoute,
 	"record-route":   headerParserRecordRoute,
 	"refer-to":       headerParserReferTo,
+	"referred-by":    headerParserReferredBy,
 }
 
 // DefaultHeadersParser returns minimal version header parser.

--- a/sip/parse_header.go
+++ b/sip/parse_header.go
@@ -56,6 +56,7 @@ var headersParsers = mapHeadersParser{
 	"l":              headerParserContentLength,
 	"route":          headerParserRoute,
 	"record-route":   headerParserRecordRoute,
+	"refer-to":       headerParserReferTo,
 }
 
 // DefaultHeadersParser returns minimal version header parser.


### PR DESCRIPTION
from #157 

Refer-to: [rfc3515](https://datatracker.ietf.org/doc/html/rfc3515)
Referred-by: [rfc3892](https://datatracker.ietf.org/doc/html/rfc3892)

for Refer-to parser, it calls `parseRouteAddress` instead of creating new one because the structure is same.
for Referred-by parser I simply copied ToHeader and FromHeader's parsing logic.