### PR TITLE
add storage for user business data in dialog

### DIFF
--- a/dialog.go
+++ b/dialog.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/emiago/sipgo/sip"
@@ -46,6 +47,9 @@ type Dialog struct {
 	cancel context.CancelFunc
 
 	onStatePointer atomic.Pointer[DialogStateFn]
+
+	// store user values
+	values sync.Map
 }
 
 // Init setups dialog state
@@ -118,4 +122,16 @@ func (d *Dialog) CSEQ() uint32 {
 
 func (d *Dialog) Context() context.Context {
 	return d.ctx
+}
+
+func (d *Dialog) Store(key string, value any) {
+	d.values.Store(key, value)
+}
+
+func (d *Dialog) Load(key string) (any, bool) {
+	return d.values.Load(key)
+}
+
+func (d *Dialog) Delete(key string) {
+	d.values.Delete(key)
 }


### PR DESCRIPTION
Enhance user data storage capability in dialog, allowing some data during invite to be stored in the dialog and used during ack and bye.

Or see if there is a more reasonable solution.