### PR TITLE
Fix TODO for non-routable contact address in BYE

### DIFF
--- a/dialog_server.go
+++ b/dialog_server.go
@@ -328,12 +328,9 @@ func (s *DialogServerSession) Bye(ctx context.Context) error {
 		cont.Address.Host = host
 		cont.Address.Port, _ = strconv.Atoi(port)
 	}
-
-	// If contact address is non-routable, use the source address instead
-
 	bye := sip.NewRequest(sip.BYE, cont.Address)
 
-	// Set transport to match contact
+	// Set transport to the value from the contact header
 	transport, ok := cont.Address.UriParams.Get("transport")
 	if !ok {
 		if cont.Address.Scheme == "sips" {


### PR DESCRIPTION
cc @juberti
When debugging 1-800-CHATGPT, I noticed that we would fail to send SIP BYE if the contact header was non-routable (for some providers we get a 10.x.x.x address). There was an existing TODO to handle this, so I implemented the necessary logic.

I also made a nearby change to set the BYE transport to match what is specified in the Contact header. 

All existing tests pass.
 