### PR TITLE
fix: improve quoted-pairs parsing in name-addr

### DIFF
--- a/sip/parse_address.go
+++ b/sip/parse_address.go
@@ -74,10 +74,10 @@ func addressStateDisplayName(a *nameAddress, s string) (addressFSM, string, erro
 		}
 
 		if c == '"' {
-			if startQuote > endQuote {
-				endQuote = i
-			} else {
+			if startQuote < 0 {
 				startQuote = i
+			} else {
+				endQuote = i
 			}
 			continue
 		}

--- a/sip/parse_address.go
+++ b/sip/parse_address.go
@@ -65,6 +65,10 @@ func addressStateDisplayName(a *nameAddress, s string) (addressFSM, string, erro
 		}
 
 		if escaped {
+			if c == 0xA || c == 0x0D {
+				// quoted-pair  =  "\" (%x00-09 / %x0B-0C / %x0E-7F)
+				return nil, s, fmt.Errorf("invalid dipslay name, not allowed to escape '0x%02X' in '%s'", c, s)
+			}
 			escaped = false
 			continue
 		}

--- a/sip/parse_address_test.go
+++ b/sip/parse_address_test.go
@@ -59,6 +59,32 @@ func TestParseAddressValue(t *testing.T) {
 		assert.Equal(t, "*", uri.Host)
 		assert.Equal(t, true, uri.Wildcard)
 	})
+
+	t.Run("quoted-pairs", func(t *testing.T) {
+		address := "\"!\\\"#$%&/'()*+-.,0123456789:;<=>? @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_'abcdefghijklmnopqrstuvwxyz{|}\" <sip:bob@127.0.0.1:5060;user=phone>;tag=1234"
+		uri := Uri{}
+		params := NewParams()
+		displayName, err := ParseAddressValue(address, &uri, params)
+		require.NoError(t, err)
+
+		assert.Equal(t, "sip:bob@127.0.0.1:5060;user=phone", uri.String())
+		assert.Equal(t, "tag=1234", params.String())
+
+		assert.Equal(t, "!\\\"#$%&/'()*+-.,0123456789:;<=>? @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_'abcdefghijklmnopqrstuvwxyz{|}", displayName)
+		assert.Equal(t, "bob", uri.User)
+		assert.Equal(t, "", uri.Password)
+		assert.Equal(t, "127.0.0.1", uri.Host)
+		assert.Equal(t, 5060, uri.Port)
+		assert.Equal(t, false, uri.IsEncrypted())
+		assert.Equal(t, false, uri.Wildcard)
+
+		user, ok := uri.UriParams.Get("user")
+		assert.True(t, ok)
+		assert.Equal(t, 1, uri.UriParams.Length())
+		assert.Equal(t, "phone", user)
+
+	})
+
 }
 
 func TestParseAddressBad(t *testing.T) {


### PR DESCRIPTION
We uncovered an issue parsing `name-addr` headers, where an escaped quote would be wrongly considered as an "end" quote. When that happens, other special characters which should be considered part of the display name are then considered as part of the actual URI.

I've added a regression test as well.

Please let me know if you would like to see more regression tests added with this change.