### PR TITLE
fix: ignore extra INVITE request prior 100 Trying

### DIFF
--- a/sip/transaction_server_tx.go
+++ b/sip/transaction_server_tx.go
@@ -59,7 +59,7 @@ func (tx *ServerTx) Init() error {
 		tx.timer_1xx = time.AfterFunc(Timer_1xx, func() {
 			trying := NewResponseFromRequest(
 				tx.Origin(),
-				100,
+				StatusTrying,
 				"Trying",
 				nil,
 			)
@@ -79,7 +79,7 @@ func (tx *ServerTx) Init() error {
 // therefore running in seperate goroutine is needed
 func (tx *ServerTx) Receive(req *Request) error {
 	tx.mu.Lock()
-	if tx.timer_1xx != nil {
+	if tx.timer_1xx != nil && !req.IsInvite() {
 		tx.timer_1xx.Stop()
 		tx.timer_1xx = nil
 	}

--- a/sip/transaction_server_tx_test.go
+++ b/sip/transaction_server_tx_test.go
@@ -28,11 +28,14 @@ func TestServerTransactionFSM(t *testing.T) {
 		tx := NewServerTx("123", req, conn, slog.Default())
 		err := tx.Init()
 		require.NoError(t, err)
+		require.NoError(t, tx.Err())
 
 		err = tx.Receive(req)
 		require.NoError(t, err)
-
 		require.NoError(t, tx.Err())
+
+		require.NoError(t, compareFunctions(tx.currentFsmState(), tx.inviteStateProcceeding))
+		require.NotNil(t, tx.timer_1xx)
 		select {
 		case <-tx.Done():
 			t.Error("Transaction should not terminate")


### PR DESCRIPTION
Based on [RFC 3261 17 Transactions](https://datatracker.ietf.org/doc/html/rfc3261#section-17), a retransmission of an INVITE should be ignored, as per:

```
   Similarly, the purpose of the server transaction is to receive
   requests from the transport layer and deliver them to the TU.  The
   server transaction filters any request retransmissions from the
   network.
```