### PR TITLE
Add support for UDP fragmentation for large SIP messages

### DIFF
--- a/sip/sip.go
+++ b/sip/sip.go
@@ -13,6 +13,7 @@ const (
 
 var (
 	SIPDebug  bool
+	AllowUDPFragmentation bool = false
 	siptracer SIPTracer
 )
 

--- a/sip/transport_udp.go
+++ b/sip/transport_udp.go
@@ -418,7 +418,7 @@ func (c *UDPConnection) WriteMsg(msg Message) error {
 	msg.StringWrite(buf)
 	data := buf.Bytes()
 
-	if len(data) > UDPMTUSize-200 {
+	if !AllowUDPFragmentation && len(data) > UDPMTUSize-200 {
 		return ErrUDPMTUCongestion
 	}
 


### PR DESCRIPTION
This PR addresses issue #206 by enabling UDP fragmentation for SIP messages that exceed the MTU size.