### PR TITLE
Add user agent logging option

### DIFF
--- a/sip/transaction_layer.go
+++ b/sip/transaction_layer.go
@@ -29,11 +29,13 @@ type TransactionLayer struct {
 	log *slog.Logger
 }
 
-type TransactionLayerOption func(tpl *TransportLayer)
+type TransactionLayerOption func(tpl *TransactionLayer)
 
 func WithTransactionLayerLogger(l *slog.Logger) TransactionLayerOption {
-	return func(tpl *TransportLayer) {
-		tpl.log = l
+	return func(txl *TransactionLayer) {
+		if l != nil {
+			txl.log = l.With("caller", "TransactionLayer")
+		}
 	}
 }
 
@@ -47,6 +49,11 @@ func NewTransactionLayer(tpl *TransportLayer, options ...TransactionLayerOption)
 		unRespHandler: defaultUnhandledRespHandler,
 	}
 	txl.log = slog.With("caller", "TransactionLayer")
+
+	for _, o := range options {
+		o(txl)
+	}
+
 	//Send all transport messages to our transaction layer
 	tpl.OnMessage(txl.handleMessage)
 	return txl

--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -47,7 +47,9 @@ type TransportLayerOption func(l *TransportLayer)
 
 func WithTransportLayerLogger(logger *slog.Logger) TransportLayerOption {
 	return func(l *TransportLayer) {
-		l.log = logger
+		if logger != nil {
+			l.log = logger.With("caller", "TransportLayer")
+		}
 	}
 }
 

--- a/ua.go
+++ b/ua.go
@@ -13,6 +13,8 @@ type UserAgent struct {
 	dnsResolver *net.Resolver
 	tlsConfig   *tls.Config
 	parser      *sip.Parser
+	txOptions   []sip.TransactionLayerOption
+	tpOptions   []sip.TransportLayerOption
 	tp          *sip.TransportLayer
 	tx          *sip.TransactionLayer
 }
@@ -62,6 +64,22 @@ func WithUserAgentParser(p *sip.Parser) UserAgentOption {
 	}
 }
 
+// WithUserAgentTransactionLayerOptions allows setting options for the transaction layer
+func WithUserAgentTransactionLayerOptions(o ...sip.TransactionLayerOption) UserAgentOption {
+	return func(s *UserAgent) error {
+		s.txOptions = o
+		return nil
+	}
+}
+
+// WithUserAgentTransportLayerOptions allows setting options for the transport layer
+func WithUserAgentTransportLayerOptions(o ...sip.TransportLayerOption) UserAgentOption {
+	return func(s *UserAgent) error {
+		s.tpOptions = o
+		return nil
+	}
+}
+
 // NewUA creates User Agent
 // User Agent will create transport and transaction layer
 // Check options for customizing user agent
@@ -79,8 +97,8 @@ func NewUA(options ...UserAgentOption) (*UserAgent, error) {
 		}
 	}
 
-	ua.tp = sip.NewTransportLayer(ua.dnsResolver, ua.parser, ua.tlsConfig)
-	ua.tx = sip.NewTransactionLayer(ua.tp)
+	ua.tp = sip.NewTransportLayer(ua.dnsResolver, ua.parser, ua.tlsConfig, ua.tpOptions...)
+	ua.tx = sip.NewTransactionLayer(ua.tp, ua.txOptions...)
 	return ua, nil
 }
 


### PR DESCRIPTION
It is possible to replace the logging in the library using WithServerLogger and WithClientLogger. This pull request adds an equivalent WithUserAgentLogger to replace the logger for the transaction and transport layer that are created by the UA. 

In addition, it ensures that the transports use the logger when debugging trace messages so that they are output to the transport and transaction logger rather than the global slog.