### PR TITLE
Issue 207: Add Request.AdvertisedHost Field

### DIFF
--- a/sip/message.go
+++ b/sip/message.go
@@ -131,9 +131,9 @@ type MessageData struct {
 	tp         string
 
 	// This is for internal routing
-	src    string
-	dest   string
-	ViaNAT bool
+	src            string
+	dest           string
+	AdvertisedHost string
 }
 
 func (msg *MessageData) Body() []byte {

--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -417,6 +417,9 @@ func (l *TransportLayer) ClientRequestConnection(ctx context.Context, req *Reque
 				viaHop.Host = host
 			}
 			viaHop.Port = port
+			if req.AdvertisedHost != "" {
+				viaHop.Host = req.AdvertisedHost
+			}
 			return c, nil
 		}
 
@@ -470,6 +473,9 @@ func (l *TransportLayer) ClientRequestConnection(ctx context.Context, req *Reque
 			viaHop.Host = host
 		}
 		viaHop.Port = port
+	}
+	if req.AdvertisedHost != "" {
+		viaHop.Host = req.AdvertisedHost
 	}
 	return c, nil
 }

--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -385,6 +385,9 @@ func (l *TransportLayer) ClientRequestConnection(ctx context.Context, req *Reque
 	if laddr.IP != nil && laddr.Port > 0 {
 		c = transport.GetConnection(laddr.String())
 		if c != nil {
+			if req.AdvertisedHost != "" {
+				viaHop.Host = req.AdvertisedHost
+			}
 			return c, nil
 		}
 	} else if l.ConnectionReuse {
@@ -467,10 +470,6 @@ func (l *TransportLayer) ClientRequestConnection(ctx context.Context, req *Reque
 			viaHop.Host = host
 		}
 		viaHop.Port = port
-	}
-
-	if req.AdvertisedHost != "" {
-		viaHop.Host = req.AdvertisedHost
 	}
 	return c, nil
 }

--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -376,13 +376,8 @@ func (l *TransportLayer) ClientRequestConnection(ctx context.Context, req *Reque
 	}
 
 	laddr := Addr{
-		IP:   nil,
+		IP:   net.ParseIP(viaHop.Host),
 		Port: viaHop.Port,
-	}
-
-	// If request is sent behind NAT, we need to avoid binding this to IP
-	if !req.ViaNAT {
-		laddr.IP = net.ParseIP(viaHop.Host)
 	}
 
 	// Always check does connection exists if full IP:port provided
@@ -472,6 +467,10 @@ func (l *TransportLayer) ClientRequestConnection(ctx context.Context, req *Reque
 			viaHop.Host = host
 		}
 		viaHop.Port = port
+	}
+
+	if req.AdvertisedHost != "" {
+		viaHop.Host = req.AdvertisedHost
 	}
 	return c, nil
 }


### PR DESCRIPTION
This PR implements Request.AdvertisedHost, as suggested in [this comment](https://github.com/emiago/sipgo/issues/207#issuecomment-2733100760) for issue #207.

The concept of AdvertisedHost is inspired by how Kamailio handles it in its configuration:

```ini
listen=udp:0.0.0.0:5060 advertise PUBLIC_IP:5060 name "udp_public"  
```

@emiago Let me know if this approach aligns with your expectations.