### PR TITLE
fix: send BYE to VIA destination if rport flag is set

### DIFF
--- a/dialog_server.go
+++ b/dialog_server.go
@@ -322,8 +322,19 @@ func (s *DialogServerSession) WriteResponse(res *sip.Response) error {
 
 func (s *DialogServerSession) Bye(ctx context.Context) error {
 	req := s.Dialog.InviteRequest
+	via := s.Dialog.InviteRequest.Via()
+
 	cont := s.Dialog.InviteRequest.Contact()
-	bye := sip.NewRequest(sip.BYE, cont.Address)
+
+	destination := cont.Address
+	if _, ok := via.Params.Get("rport"); ok {
+		destination = sip.Uri{
+			Host: via.Host,
+			Port: via.Port,
+		}
+	}
+
+	bye := sip.NewRequest(sip.BYE, destination)
 	bye.SetTransport(req.Transport())
 
 	return s.WriteBye(ctx, bye)


### PR DESCRIPTION
[RFC 3581](https://datatracker.ietf.org/doc/html/rfc3581.html#section-4) says that we should send responses back using the received IP address and PORT if the VIA header contains the rport parameter.

[RFC 6313](https://datatracker.ietf.org/doc/html/rfc6314#section-4.1.1) specifies that we should use symmetric responses when we receive rport in the INVITE via header. We therefore think RFC3581 applies to the BYE request as well as INVITE responses.

This pull request suggests a change to sending the BYE request using the INVITE VIA header if it contains the rport parameter. We need this to support symmetric natting in our network infrastructure. We have tested this a PJSUA client running on a GSM network, and the BYE request is received with this change.

Please consider if this is appropriate behaviour for SIPGO.