### PR TITLE
fix: nil UriParams when uri with port

### DIFF
--- a/sip/parse_address_test.go
+++ b/sip/parse_address_test.go
@@ -48,6 +48,20 @@ func TestParseAddressValue(t *testing.T) {
 		assert.Equal(t, false, uri.IsEncrypted())
 	})
 
+	t.Run("nil uri params", func(t *testing.T) {
+		address := "sip:1215174826@222.222.222.222:5066"
+		uri := Uri{}
+		params := NewParams()
+		displayName, err := ParseAddressValue(address, &uri, params)
+		require.NoError(t, err)
+
+		assert.Equal(t, "", displayName)
+		assert.Equal(t, "1215174826", uri.User)
+		assert.Equal(t, "222.222.222.222", uri.Host)
+		assert.Equal(t, HeaderParams{}, uri.UriParams)
+		assert.Equal(t, false, uri.IsEncrypted())
+	})
+
 	t.Run("wildcard", func(t *testing.T) {
 		address := "*"
 		uri := Uri{}

--- a/sip/parse_uri.go
+++ b/sip/parse_uri.go
@@ -120,7 +120,7 @@ func uriStatePort(uri *Uri, s string) (uriFSM, string, error) {
 	}
 
 	uri.Port, err = strconv.Atoi(s)
-	return nil, s, err
+	return uriStateUriParams, "", err
 }
 
 func uriStateUriParams(uri *Uri, s string) (uriFSM, string, error) {


### PR DESCRIPTION
Hi,

When the URI contains a port and no params, `UriParams` will be nil, and calling `UriParams.Add` will panic.

If the URI does not contain a port, it works fine. From the code, it is found that if the port is not included, `uriFSM` will return `uriStateUriParams`, so `uriStateUriParams` should also be returned when the port exists.