### PR TITLE
feat: expose LocalAddr for Transaction

### DIFF
--- a/sip/transaction.go
+++ b/sip/transaction.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -103,6 +104,9 @@ type Transaction interface {
 	Done() <-chan struct{}
 	// Last error. Useful to check when transaction terminates
 	Err() error
+
+	// LocalAddr returns the local network address
+	LocalAddr() net.Addr
 }
 
 type ServerTransaction interface {
@@ -183,6 +187,10 @@ func (tx *baseTx) Origin() *Request {
 
 func (tx *baseTx) Key() string {
 	return tx.key
+}
+
+func (tx *baseTx) LocalAddr() net.Addr {
+	return tx.conn.LocalAddr()
 }
 
 func (tx *baseTx) Done() <-chan struct{} {


### PR DESCRIPTION
Hi, @emiago 

According to the discussion in the issue, this PR only exposes the `LocalAddr` method, not the complete `Connection`.

Close: https://github.com/emiago/sipgo/issues/218