### PR TITLE
feat: enable to customize TCP dialer

### DIFF
--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -26,6 +26,8 @@ type TransportLayer struct {
 	ws  *transportWS
 	wss *transportWSS
 
+	tcpDialer *net.Dialer
+
 	transports map[string]Transport
 
 	listenPorts   map[string][]int
@@ -50,6 +52,12 @@ func WithTransportLayerLogger(logger *slog.Logger) TransportLayerOption {
 		if logger != nil {
 			l.log = logger.With("caller", "TransportLayer")
 		}
+	}
+}
+
+func WithTransportLayerTCPDialer(dialer *net.Dialer) TransportLayerOption {
+	return func(l *TransportLayer) {
+		l.tcpDialer = dialer
 	}
 }
 
@@ -89,7 +97,8 @@ func NewTransportLayer(
 
 	// TCP
 	l.tcp = &transportTCP{
-		log: l.log.With("caller", "Transport<TCP>"),
+		log:    l.log.With("caller", "Transport<TCP>"),
+		dialer: l.tcpDialer,
 	}
 	l.tcp.init(sipparser)
 

--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -17,6 +17,7 @@ type transportTCP struct {
 	transport string
 	parser    *Parser
 	log       *slog.Logger
+	dialer    *net.Dialer
 
 	pool *ConnectionPool
 }
@@ -87,8 +88,14 @@ func (t *transportTCP) createConnection(ctx context.Context, laddr *net.TCPAddr,
 	addr := raddr.String()
 	t.log.Debug("Dialing new connection", "raddr", addr)
 
-	d := net.Dialer{
-		LocalAddr: laddr,
+	var d *net.Dialer
+	if t.dialer != nil {
+		d = t.dialer
+		d.LocalAddr = laddr
+	} else {
+		d = &net.Dialer{
+			LocalAddr: laddr,
+		}
 	}
 	conn, err := d.DialContext(ctx, "tcp", addr)
 	if err != nil {


### PR DESCRIPTION
Example:

```go
control := func(network, address string, c syscall.RawConn) (err error) {
	controlErr := c.Control(func(fd uintptr) {
		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
		if err != nil {
			return
		}
		err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
	})
	if controlErr != nil {
		err = controlErr
	}
	return
}
dialer := &net.Dialer{
	Control: control,
}
ua, _ := sipgo.NewUA(
	sipgo.WithUserAgentTransportLayerOptions(sip.WithTransportLayerTCPDialer(dialer)),
)
```