### PR TITLE
Handle case in Uri Addr() where no User is available

### DIFF
--- a/sip/uri.go
+++ b/sip/uri.go
@@ -132,7 +132,10 @@ func (uri *Uri) Addr() string {
 		scheme = "sip"
 	}
 
-	addr := uri.User + "@" + uri.Host
+	addr := uri.Host
+	if uri.User != "" {
+		addr = uri.User + "@" + addr
+	}
 	if uri.Port > 0 {
 		addr += ":" + strconv.Itoa(uri.Port)
 	}


### PR DESCRIPTION
* This is done to prevent invalid Authorization headers being created like:

Authorization: Digest username="myUser", realm="sipserver", nonce="12345", uri="sip:@vc.voipoperator.de", response="abcdefg"

In particular the @ sign causes Auth to fail: uri="sip:@vc.voipoperator.de"