### PR TITLE
Add a nil check guard in actResend():

### DIFF
--- a/sip/transaction_client_tx_fsm.go
+++ b/sip/transaction_client_tx_fsm.go
@@ -223,7 +223,10 @@ func (tx *ClientTx) actResend() fsmInput {
 	if tx.timer_a_time > T2 {
 		tx.timer_a_time = T2
 	}
-	tx.timer_a.Reset(tx.timer_a_time)
+
+	if tx.timer_a != nil {
+		tx.timer_a.Reset(tx.timer_a_time)
+	}
 
 	tx.mu.Unlock()
 


### PR DESCRIPTION
sip: prevent nil pointer dereference in client transaction resend

Under high load conditions when server responses are delayed, terminated
transactions could attempt to resend after cleanup, causing a panic due
to nil timerA. This occurs when the state machine processes events after
Terminate() has cleared the timers.

Add a nil check guard in actResend() to safely skip reset operations on
terminated transactions. This prevents the segmentation fault while
maintaining correct behavior for active transactions.

Fixes: https://github.com/emiago/sipgo/issues/238"