### PR TITLE
fix: max ipv6 length updated

### DIFF
--- a/sip/parse_uri.go
+++ b/sip/parse_uri.go
@@ -116,9 +116,9 @@ func uriStateHost(uri *Uri, s string) (uriFSM, string, error) {
 }
 
 func uriStateHostIPV6(uri *Uri, s string) (uriFSM, string, error) {
-	// ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff max 39
+	// ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff max 39 + 2 brackets
 	// Do not waste time looking end
-	maxs := min(len(s), 40)
+	maxs := min(len(s), 42)
 
 	ind := strings.Index(s[:maxs], "]")
 	if ind <= 0 {

--- a/sip/parse_uri_test.go
+++ b/sip/parse_uri_test.go
@@ -178,6 +178,16 @@ func TestParseUriIPV6(t *testing.T) {
 		assert.Equal(t, 5060, uri.Port)
 	})
 
+	t.Run("max length", func(t *testing.T) {
+		uri := Uri{}
+		str := "sip:[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:5060"
+		err := ParseUri(str, &uri)
+		require.NoError(t, err)
+
+		assert.Equal(t, "[2001:0db8:85a3:0000:0000:8a2e:0370:7334]", uri.Host)
+		assert.Equal(t, 5060, uri.Port)
+	})
+
 	t.Run("with params", func(t *testing.T) {
 		uri := Uri{}
 		str := "sip:[fe80::dc45:996b:6de9:9746]:5060;rport;branch=z9hG4bKPj6c65c5d9-b6d0-4a30-9383-1f9b42f97de9"


### PR DESCRIPTION
uri error when the ipv6 max length is used, updated to include max length plus two brackets.