### PR TITLE
fix: accommodate leading bracket in uriStateHostIPV6

### DIFF
--- a/sip/parse_uri.go
+++ b/sip/parse_uri.go
@@ -116,9 +116,9 @@ func uriStateHost(uri *Uri, s string) (uriFSM, string, error) {
 }
 
 func uriStateHostIPV6(uri *Uri, s string) (uriFSM, string, error) {
-	// ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff max 39
+	// [ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff max 40
 	// Do not waste time looking end
-	maxs := min(len(s), 40)
+	maxs := min(len(s), 41)
 
 	ind := strings.Index(s[:maxs], "]")
 	if ind <= 0 {


### PR DESCRIPTION
IPv6 addresses passed to uriStateHostIPV6 have a leading bracket, the trailing bracket can be at character position 41.