### PR TITLE
Add ad-hoc dialog creation

### DIFF
--- a/dialog.go
+++ b/dialog.go
@@ -144,3 +144,7 @@ func (d *Dialog) CSEQ() uint32 {
 func (d *Dialog) Context() context.Context {
 	return d.ctx
 }
+
+func (d *Dialog) SetCSEQ(cseq uint32) {
+	d.lastCSeqNo.Store(cseq)
+}

--- a/dialog_ua.go
+++ b/dialog_ua.go
@@ -29,7 +29,8 @@ type DialogSessionParams struct {
 	// State is the active dialog state.
 	State sip.DialogState
 	// CSeq is the last CSeq number to set in dialog.
-	CSeq uint32
+	CSeq     uint32
+	DialogID string
 }
 
 // NewServerSession generates a DialogServerSession without creating a transaction for the initial INVITE.
@@ -38,18 +39,10 @@ func (ua *DialogUA) NewServerSession(params DialogSessionParams) (*DialogServerS
 	if params.InviteReq == nil {
 		return nil, errors.New("invite request is required")
 	}
-	if params.InviteResp == nil {
-		return nil, errors.New("invite response is required")
-	}
-
-	dialogID, err := sip.UASReadRequestDialogID(params.InviteReq)
-	if err != nil {
-		return nil, fmt.Errorf("error reading dialog ID from request: %w", err)
-	}
 
 	dtx := &DialogServerSession{
 		Dialog: Dialog{
-			ID:             dialogID,
+			ID:             params.DialogID,
 			InviteRequest:  params.InviteReq,
 			InviteResponse: params.InviteResp,
 		},
@@ -135,18 +128,10 @@ func (ua *DialogUA) NewClientSession(params DialogSessionParams) (*DialogClientS
 	if params.InviteReq == nil {
 		return nil, errors.New("invite request is required")
 	}
-	if params.InviteResp == nil {
-		return nil, errors.New("invite response is required")
-	}
-
-	dialogID, err := sip.UACReadRequestDialogID(params.InviteReq)
-	if err != nil {
-		return nil, fmt.Errorf("error reading dialog ID from request: %w", err)
-	}
 
 	dtx := &DialogClientSession{
 		Dialog: Dialog{
-			ID:             dialogID,
+			ID:             params.DialogID,
 			InviteRequest:  params.InviteReq,
 			InviteResponse: params.InviteResp,
 		},

--- a/dialog_ua.go
+++ b/dialog_ua.go
@@ -125,7 +125,7 @@ func (c *DialogUA) ReadInvite(inviteReq *sip.Request, tx sip.ServerTransaction) 
 	return dtx, nil
 }
 
-// NewClientSession generates a DialogClientSession without creating a transaction for the initial INVITE.
+// NewClientSession generates a DialogClientSession without sending out an INVITE.
 // Only use this if the initial transaction has already been completed.
 func (ua *DialogUA) NewClientSession(params DialogSessionParams) (*DialogClientSession, error) {
 	if params.InviteReq == nil {

--- a/dialog_ua.go
+++ b/dialog_ua.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync/atomic"
-
 	"github.com/emiago/sipgo/sip"
 	"github.com/google/uuid"
 )
@@ -27,6 +25,7 @@ type DialogSessionParams struct {
 	InviteReq  *sip.Request
 	InviteResp *sip.Response
 	State      sip.DialogState
+	CSeq       uint32
 }
 
 // NewServerSession generates a DialogServerSession without creating a transaction for the initial INVITE.
@@ -52,13 +51,13 @@ func (ua *DialogUA) NewServerSession(params DialogSessionParams) (*DialogServerS
 		Dialog: Dialog{
 			ID:             dialogID,
 			InviteRequest:  params.InviteReq,
-			lastCSeqNo:     atomic.Uint32{},
 			InviteResponse: params.InviteResp,
 		},
 		inviteTx: &NoOpServerTransaction{},
 		ua:       ua,
 	}
 	dtx.InitWithState(params.State)
+	dtx.SetCSEQ(params.CSeq)
 
 	return dtx, nil
 }

--- a/dialog_ua.go
+++ b/dialog_ua.go
@@ -22,10 +22,14 @@ type DialogUA struct {
 }
 
 type DialogSessionParams struct {
-	InviteReq  *sip.Request
+	// InviteReq is the initial INVITE request that started the dialog.
+	InviteReq *sip.Request
+	// InviteResp is the response to the initial INVITE request.
 	InviteResp *sip.Response
-	State      sip.DialogState
-	CSeq       uint32
+	// State is the active dialog state.
+	State sip.DialogState
+	// CSeq is the last CSeq number to set in dialog.
+	CSeq uint32
 }
 
 // NewServerSession generates a DialogServerSession without creating a transaction for the initial INVITE.

--- a/dialog_ua.go
+++ b/dialog_ua.go
@@ -135,7 +135,7 @@ func (ua *DialogUA) NewClientSession(params DialogSessionParams) (*DialogClientS
 		return nil, errors.New("invite response is required")
 	}
 
-	dialogID, err := sip.UASReadRequestDialogID(params.InviteReq)
+	dialogID, err := sip.UACReadRequestDialogID(params.InviteReq)
 	if err != nil {
 		return nil, fmt.Errorf("error reading dialog ID from request: %w", err)
 	}

--- a/noop_transaction.go
+++ b/noop_transaction.go
@@ -67,3 +67,13 @@ func (t *NoOpServerTransaction) Acks() <-chan *sip.Request {
 func (t *NoOpTransaction) OnCancel(_ sip.FnTxCancel) bool {
 	return false
 }
+
+type NoOpClientTransaction struct {
+	NoOpTransaction
+}
+
+var _ sip.ClientTransaction = &NoOpClientTransaction{}
+
+func (t *NoOpClientTransaction) OnRetransmission(_ sip.FnTxResponse) bool {
+	return false
+}

--- a/noop_transaction.go
+++ b/noop_transaction.go
@@ -38,13 +38,13 @@ func (t *NoOpTransaction) OnTerminate(_ sip.FnTxTerminate) bool {
 	return false
 }
 
-// setResponses sets the response channel for this transaction
-func (t *NoOpTransaction) setResponses(ch <-chan *sip.Response) {
+// SetResponses sets the response channel for this transaction
+func (t *NoOpTransaction) SetResponses(ch <-chan *sip.Response) {
 	t.respCh = ch
 }
 
-// setDone sets the done channel for this transaction
-func (t *NoOpTransaction) setDone(ch <-chan struct{}) {
+// SetDone sets the done channel for this transaction
+func (t *NoOpTransaction) SetDone(ch <-chan struct{}) {
 	t.doneCh = ch
 }
 

--- a/noop_transaction.go
+++ b/noop_transaction.go
@@ -1,0 +1,57 @@
+package sipgo
+
+import "github.com/emiago/sipgo/sip"
+
+type NoOpTransaction struct {
+	respCh <-chan *sip.Response
+	doneCh <-chan struct{}
+}
+
+func (t *NoOpTransaction) Terminate() {}
+
+func (t *NoOpTransaction) Done() <-chan struct{} {
+	if t.doneCh != nil {
+		return t.doneCh
+	}
+	doneCh := make(chan struct{})
+	close(doneCh)
+	return doneCh
+}
+
+func (t *NoOpTransaction) Err() error {
+	return nil
+}
+
+// Responses implements sip.ClientTransaction interface.
+func (t *NoOpTransaction) Responses() <-chan *sip.Response {
+	if t.respCh != nil {
+		return t.respCh
+	}
+	respCh := make(chan *sip.Response)
+	close(respCh)
+	return respCh
+}
+
+// setResponses sets the response channel for this transaction
+func (t *NoOpTransaction) setResponses(ch <-chan *sip.Response) {
+	t.respCh = ch
+}
+
+// setDone sets the done channel for this transaction
+func (t *NoOpTransaction) setDone(ch <-chan struct{}) {
+	t.doneCh = ch
+}
+
+type NoOpServerTransaction struct {
+	NoOpTransaction
+}
+
+func (t *NoOpServerTransaction) Respond(_ *sip.Response) error {
+	return nil
+}
+
+func (t *NoOpServerTransaction) Acks() <-chan *sip.Request {
+	reqCh := make(chan *sip.Request)
+	close(reqCh)
+	return reqCh
+}

--- a/noop_transaction.go
+++ b/noop_transaction.go
@@ -7,6 +7,8 @@ type NoOpTransaction struct {
 	doneCh <-chan struct{}
 }
 
+var _ sip.Transaction = &NoOpTransaction{}
+
 func (t *NoOpTransaction) Terminate() {}
 
 func (t *NoOpTransaction) Done() <-chan struct{} {
@@ -32,6 +34,10 @@ func (t *NoOpTransaction) Responses() <-chan *sip.Response {
 	return respCh
 }
 
+func (t *NoOpTransaction) OnTerminate(_ sip.FnTxTerminate) bool {
+	return false
+}
+
 // setResponses sets the response channel for this transaction
 func (t *NoOpTransaction) setResponses(ch <-chan *sip.Response) {
 	t.respCh = ch
@@ -46,6 +52,8 @@ type NoOpServerTransaction struct {
 	NoOpTransaction
 }
 
+var _ sip.ServerTransaction = &NoOpServerTransaction{}
+
 func (t *NoOpServerTransaction) Respond(_ *sip.Response) error {
 	return nil
 }
@@ -54,4 +62,8 @@ func (t *NoOpServerTransaction) Acks() <-chan *sip.Request {
 	reqCh := make(chan *sip.Request)
 	close(reqCh)
 	return reqCh
+}
+
+func (t *NoOpTransaction) OnCancel(_ sip.FnTxCancel) bool {
+	return false
 }


### PR DESCRIPTION
Related to: https://github.com/emiago/sipgo/issues/242.

Allows the creation of `DialogClientSession` / `DialogServerSession` after the initial transaction has been completed. This is useful in failover and redundancy scenarios where different transactions within a dialog may be handled by different servers.