### PR TITLE
fix: add content length header to bye

### DIFF
--- a/dialog_server.go
+++ b/dialog_server.go
@@ -358,6 +358,7 @@ func (s *DialogServerSession) Bye(ctx context.Context) error {
 	req := s.Dialog.InviteRequest
 	cont := s.Dialog.InviteRequest.Contact()
 	bye := sip.NewRequest(sip.BYE, cont.Address)
+	bye.SetBody(nil) // Add Content-Length header
 	bye.SetTransport(req.Transport())
 
 	return s.WriteBye(ctx, bye)


### PR DESCRIPTION
When using TCP / TLS transport, when sending a BYE a warning is received that the content length header is not provided.

This pull request adds a Content-Length header of 0 to outgoing BYE requests.