### PR TITLE
fix: ClientTx change to proceeding state can't stop timer_b.

### DIFF
--- a/sip/transaction_client_tx_fsm.go
+++ b/sip/transaction_client_tx_fsm.go
@@ -246,10 +246,6 @@ func (tx *ClientTx) actInviteProceeding() fsmInput {
 		tx.timer_a.Stop()
 		tx.timer_a = nil
 	}
-	if tx.timer_b != nil {
-		tx.timer_b.Stop()
-		tx.timer_b = nil
-	}
 
 	tx.mu.Unlock()
 


### PR DESCRIPTION
timer_b is timeout of the whole tranction including final response.

Bug Scenario: UAS response 1xx but no 2xx, the tx will still forever.