### PR TITLE
fix: ParserStream handling StartLine and incomplete Header

### DIFF
--- a/sip/parser_stream.go
+++ b/sip/parser_stream.go
@@ -115,6 +115,7 @@ func (p *ParserStream) parseSingle(reader *bytes.Buffer, unparsed *[]byte) (err 
 			return err
 		}
 
+		*unparsed = reader.Bytes()
 		p.state = stateHeader
 		p.msg = msg
 		fallthrough

--- a/sip/parser_stream_test.go
+++ b/sip/parser_stream_test.go
@@ -327,6 +327,34 @@ func TestParserStreamMessageSizeLimit(t *testing.T) {
 	require.Equal(t, "Message exceeds ParseMaxMessageLength", err.Error())
 }
 
+func TestParserStreamPartialAfterStartLine(t *testing.T) {
+	p := NewParser()
+	parser := p.NewSIPStream()
+
+	lines1 := []string{
+		"SIP/2.0 481 Call/Transaction Does Not Exist",
+		"Via: SIP/2.0/TCP 10.10.42.37:48476;received=10.10.42.37;bran",
+	}
+	input1 := []byte(strings.Join(lines1, "\r\n"))
+
+	lines2 := []string{
+		"ch=z9hG4bK.9WUsakU92PFG5mIv",
+		"Call-ID: 2227040c-914c-4496-a715-1a93c9501360",
+		"From: \"sipgo\" <sip:sipgo@localhost>;tag=Ffl4DGpHt5yvhgU2",
+		"To: <sip:Port25@10.10.42.64>;tag=z9hG4bK.9WUsakU92PFG5mIv",
+		"CSeq: 1 CANCEL",
+		"Content-Length:  0",
+		"",
+		"",
+	}
+	input2 := []byte(strings.Join(lines2, "\r\n"))
+
+	_, err := parser.ParseSIPStream(input1)
+	require.Error(t, err)
+	_, err = parser.ParseSIPStream(input2)
+	require.NoError(t, err)
+}
+
 func BenchmarkParserStream(b *testing.B) {
 	branch := GenerateBranch()
 	callid := fmt.Sprintf("gotest-%d", time.Now().UnixNano())


### PR DESCRIPTION
Before the fix, when ParserStream got an partial message only containing a StartLine and parts of the following header, it failed with 'field name with no value in header: EOF on reading line' We need to adjust the unparsed slice after reading the StartLine.