### PR TITLE
fix according RFC3261 12.1 Creation of a Dialog

### DIFF
--- a/dialog_client.go
+++ b/dialog_client.go
@@ -453,7 +453,7 @@ func (s *DialogClientSession) WriteBye(ctx context.Context, bye *sip.Request) er
 }
 
 func (s *DialogClientSession) isEarlyDialog() bool {
-	return s.InviteResponse != nil && s.InviteResponse.IsProvisional()
+	return s.InviteResponse != nil && s.InviteResponse.IsProvisional() && s.InviteResponse.StatusCode != 100
 }
 
 // newAckRequestUAC creates ACK request for 2xx INVITE


### PR DESCRIPTION
Fix for recent commit be7c0f45f373663d60093d8fb31a205cb0b1a9b4. 
To send early BYE we must to have to-tag.

According RFC3261
> 12.1 Creation of a Dialog
> 
>    Dialogs are created through the generation of non-failure responses
>    to requests with specific methods.  Within this specification, only
>    2xx and 101-199 responses with a To tag, where the request was
>    INVITE, will establish a dialog.