### PR TITLE
transport_tcp: add read and write deadline

### DIFF
--- a/fakes/tcp_conn.go
+++ b/fakes/tcp_conn.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 )
 
 type TCPConn struct {
@@ -48,6 +49,14 @@ func (c *TCPConn) Write(p []byte) (n int, err error) {
 }
 
 func (c *TCPConn) Close() error {
+	return nil
+}
+
+func (c *TCPConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *TCPConn) SetWriteDeadline(time.Time) error {
 	return nil
 }
 

--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 	"time"
 )
@@ -160,7 +161,7 @@ func (t *TransportTCP) readConnection(conn *TCPConnection, laddr string, raddr s
 
 	for {
 		num, err := conn.Read(buf)
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrDeadlineExceeded) {
 			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
 				t.log.Debug("connection was closed", "error", err)
 				return
@@ -184,7 +185,7 @@ func (t *TransportTCP) readConnection(conn *TCPConnection, laddr string, raddr s
 				t.log.Debug("Keep alive CRLF received")
 				if datalen == 4 {
 					// 2 CRLF is ping
-					if _, err := conn.Write(data[:2]); err != nil {
+					if _, err := conn.Write(data[:2]); err != nil && !errors.Is(err, os.ErrDeadlineExceeded) {
 						t.log.Error("Failed to pong keep alive", "error", err)
 						return
 					}
@@ -261,6 +262,9 @@ func (c *TCPConnection) TryClose() (int, error) {
 
 func (c *TCPConnection) Read(b []byte) (n int, err error) {
 	// Some debug hook. TODO move to proper way
+	if err := c.Conn.SetReadDeadline(time.Now().Add(time.Millisecond * 500)); err != nil {
+		slog.Warn("Failed to set read deadline", "ip", c.LocalAddr().String(), "dst", c.RemoteAddr().String(), "error", err)
+	}
 	n, err = c.Conn.Read(b)
 	if SIPDebug {
 		logSIPRead("TCP", c.Conn.LocalAddr().String(), c.Conn.RemoteAddr().String(), b[:n])
@@ -270,6 +274,9 @@ func (c *TCPConnection) Read(b []byte) (n int, err error) {
 
 func (c *TCPConnection) Write(b []byte) (n int, err error) {
 	// Some debug hook. TODO move to proper way
+	if err := c.Conn.SetWriteDeadline(time.Now().Add(time.Millisecond * 500)); err != nil {
+		slog.Warn("Failed to set write deadline", "ip", c.LocalAddr().String(), "dst", c.RemoteAddr().String(), "error", err)
+	}
 	n, err = c.Conn.Write(b)
 	if SIPDebug {
 		logSIPWrite("TCP", c.Conn.LocalAddr().String(), c.Conn.RemoteAddr().String(), b[:n])


### PR DESCRIPTION
add read and write deadline for tcp transport, otherwise it takes a long time to detect offline devices.