### PR TITLE
transport_tcp: reduce TransportBuffer Size to not overload parser

### DIFF
--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -147,7 +147,7 @@ func (t *TransportTCP) initConnection(conn net.Conn, raddr string, handler Messa
 
 // This should performe better to avoid any interface allocation
 func (t *TransportTCP) readConnection(conn *TCPConnection, laddr string, raddr string, handler MessageHandler) {
-	buf := make([]byte, TransportBufferReadSize)
+	buf := make([]byte, TransportBufferReadSize/2) // only halve to don't overload the parser buffer
 	defer t.pool.Delete(laddr)
 	defer func() {
 		if err := t.pool.CloseAndDelete(conn, raddr); err != nil {


### PR DESCRIPTION
Reduce the TransportBufferReadSize in TCP transport to not overflow the ParserStream as it's ParseMaxMessageLength is the same size.
Maybe we should generally reduce the TransportBufferReadSize.