### PR TITLE
Make header and URI parameters ordered

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,9 +8,10 @@ import (
 	"log/slog"
 	"net"
 
-	"github.com/emiago/sipgo/sip"
 	"github.com/google/uuid"
 	"github.com/icholy/digest"
+
+	"github.com/emiago/sipgo/sip"
 )
 
 func Init() {
@@ -348,13 +349,10 @@ func clientRequestBuildReq(c *Client, req *sip.Request) error {
 		from := sip.FromHeader{
 			DisplayName: c.UserAgent.name,
 			Address: sip.Uri{
-				Scheme:    req.Recipient.Scheme,
-				User:      c.UserAgent.name,
-				Host:      c.UserAgent.hostname,
-				UriParams: sip.NewParams(),
-				Headers:   sip.NewParams(),
+				Scheme: req.Recipient.Scheme,
+				User:   c.UserAgent.name,
+				Host:   c.UserAgent.hostname,
 			},
-			Params: sip.NewParams(),
 		}
 
 		if from.Address.Host == "" {
@@ -369,13 +367,10 @@ func clientRequestBuildReq(c *Client, req *sip.Request) error {
 	if v := req.To(); v == nil {
 		to := sip.ToHeader{
 			Address: sip.Uri{
-				Scheme:    req.Recipient.Scheme,
-				User:      req.Recipient.User,
-				Host:      req.Recipient.Host,
-				UriParams: sip.NewParams(),
-				Headers:   sip.NewParams(),
+				Scheme: req.Recipient.Scheme,
+				User:   req.Recipient.User,
+				Host:   req.Recipient.Host,
 			},
-			Params: sip.NewParams(),
 		}
 		mustHeader = append(mustHeader, &to)
 	}
@@ -466,7 +461,6 @@ func clientRequestCreateVia(c *Client, r *sip.Request) *sip.ViaHeader {
 		Transport:       r.Transport(),
 		Host:            c.host, // This can be rewritten by transport layer
 		Port:            c.port, // This can be rewritten by transport layer
-		Params:          sip.NewParams(),
 	}
 	// NOTE: Consider lenght of branch configurable
 	newvia.Params.Add("branch", sip.GenerateBranchN(16))
@@ -499,10 +493,9 @@ func ClientRequestAddRecordRoute(c *Client, r *sip.Request) error {
 			UriParams: sip.HeaderParams{
 				// Transport must be provided as wesll
 				// https://datatracker.ietf.org/doc/html/rfc5658
-				"transport": sip.NetworkToLower(r.Transport()),
-				"lr":        "",
+				{"transport", sip.NetworkToLower(r.Transport())},
+				{"lr", ""},
 			},
-			Headers: sip.NewParams(),
 		},
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -35,19 +35,19 @@ func TestClientRequestBuild(t *testing.T) {
 		User:      "bob",
 		Host:      "10.2.2.2",
 		Port:      5060,
-		Headers:   sip.HeaderParams{"transport": "udp"},
-		UriParams: sip.HeaderParams{"foo": "bar"},
+		Headers:   sip.HeaderParams{{"transport", "udp"}},
+		UriParams: sip.HeaderParams{{"foo", "bar"}},
 	}
 
 	req := sip.NewRequest(sip.OPTIONS, recipment)
 	clientRequestBuildReq(c, req)
 
 	via := req.Via()
-	assert.Equal(t, "SIP/2.0/UDP 10.0.0.0;branch="+via.Params["branch"], via.Value())
+	assert.Equal(t, "SIP/2.0/UDP 10.0.0.0;branch="+via.Params.GetOr("branch", ""), via.Value())
 
 	from := req.From()
 	// No ports should exists, headers, uriparams should exists, except tag
-	assert.Equal(t, "\"sipgo\" <sip:sipgo@mydomain.com>;tag="+from.Params["tag"], from.Value())
+	assert.Equal(t, "\"sipgo\" <sip:sipgo@mydomain.com>;tag="+from.Params.GetOr("tag", ""), from.Value())
 
 	to := req.To()
 	// No ports should exists, headers, uriparams should exists
@@ -79,11 +79,9 @@ func TestClientRequestBuildWithNAT(t *testing.T) {
 	require.Nil(t, err)
 
 	recipment := sip.Uri{
-		User:      "bob",
-		Host:      "10.2.2.2",
-		Port:      5060,
-		Headers:   sip.NewParams(),
-		UriParams: sip.NewParams(),
+		User: "bob",
+		Host: "10.2.2.2",
+		Port: 5060,
 	}
 
 	req := sip.NewRequest(sip.OPTIONS, recipment)
@@ -93,7 +91,7 @@ func TestClientRequestBuildWithNAT(t *testing.T) {
 	val := via.Value()
 	params := strings.Split(val, ";")
 	sort.Slice(params, func(i, j int) bool { return params[i] < params[j] })
-	assert.Equal(t, "SIP/2.0/UDP 10.0.0.0;branch="+via.Params["branch"]+";rport", strings.Join(params, ";"))
+	assert.Equal(t, "SIP/2.0/UDP 10.0.0.0;branch="+via.Params.GetOr("branch", "")+";rport", strings.Join(params, ";"))
 }
 
 func TestClientRequestBuildWithHostAndPort(t *testing.T) {
@@ -119,11 +117,11 @@ func TestClientRequestBuildWithHostAndPort(t *testing.T) {
 	clientRequestBuildReq(c, req)
 
 	via := req.Via()
-	assert.Equal(t, "SIP/2.0/UDP sip.myserver.com:5066;branch="+via.Params["branch"], via.Value())
+	assert.Equal(t, "SIP/2.0/UDP sip.myserver.com:5066;branch="+via.Params.GetOr("branch", ""), via.Value())
 
 	from := req.From()
 	// No ports should exists
-	assert.Equal(t, "\"sipgo\" <sip:sipgo@sip.myserver.com>;tag="+from.Params["tag"], from.Value())
+	assert.Equal(t, "\"sipgo\" <sip:sipgo@sip.myserver.com>;tag="+from.Params.GetOr("tag", ""), from.Value())
 
 	to := req.To()
 	// No port should exists or special values
@@ -154,15 +152,15 @@ func TestClientRequestOptions(t *testing.T) {
 	// Proxy receives this request
 	req := createSimpleRequest(sip.INVITE, sender, recipment, "UDP")
 	oldvia := req.Via()
-	assert.Equal(t, "Via: SIP/2.0/UDP 10.1.1.1:5060;branch="+oldvia.Params["branch"], oldvia.String())
+	assert.Equal(t, "Via: SIP/2.0/UDP 10.1.1.1:5060;branch="+oldvia.Params.GetOr("branch", ""), oldvia.String())
 
 	// Proxy will add via header with client host
 	err = ClientRequestAddVia(c, req)
 	require.Nil(t, err)
 	via := req.Via()
 	tmpvia := *via // Save this for later usage
-	assert.Equal(t, "Via: SIP/2.0/UDP 10.0.0.0;branch="+via.Params["branch"], via.String())
-	assert.NotEqual(t, via.Params["branch"], oldvia.Params["branch"])
+	assert.Equal(t, "Via: SIP/2.0/UDP 10.0.0.0;branch="+via.Params.GetOr("branch", ""), via.String())
+	assert.NotEqual(t, via.Params.GetOr("branch", ""), oldvia.Params.GetOr("branch", ""))
 
 	// Add Record Route
 	err = ClientRequestAddRecordRoute(c, req)

--- a/dialog_ua.go
+++ b/dialog_ua.go
@@ -38,7 +38,7 @@ func (c *DialogUA) ReadInvite(inviteRequest *sip.Request, tx sip.ServerTransacti
 	}
 	// As we are modifying request we need to perform shallow clone to avoid transaction races
 	inviteReq := inviteRequest.Clone()
-	inviteReq.To().Params["tag"] = uuid.String()
+	inviteReq.To().Params.Add("tag", uuid.String())
 	id, err := sip.DialogIDFromRequestUAS(inviteReq)
 	if err != nil {
 		return nil, err

--- a/example/proxysip/main.go
+++ b/example/proxysip/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime"
@@ -19,8 +20,6 @@ import (
 
 	"github.com/arl/statsviz"
 	"github.com/emiago/sipgo/sip"
-
-	_ "net/http/pprof"
 
 	"github.com/emiago/sipgo"
 
@@ -258,7 +257,7 @@ func setupSipProxy(proxydst string, ip string) *sipgo.Server {
 		res := sip.NewResponseFromRequest(req, 200, "OK", nil)
 		// log.Debug().Msgf("Sending response: \n%s", res.String())
 
-		// URI params must be reset or this should be regenetad
+		// URI params must be reset or this should be regenerated
 		cont.Address.UriParams = sip.NewParams()
 		cont.Address.UriParams.Add("transport", req.Transport())
 

--- a/server_test.go
+++ b/server_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/emiago/sipgo/fakes"
-	"github.com/emiago/sipgo/sip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/emiago/sipgo/fakes"
+	"github.com/emiago/sipgo/sip"
 )
 
 func testCreateMessage(t testing.TB, rawMsg []string) sip.Message {
@@ -26,8 +27,8 @@ func testCreateMessage(t testing.TB, rawMsg []string) sip.Message {
 
 func createSimpleRequest(method sip.RequestMethod, sender sip.Uri, recipment sip.Uri, transport string) *sip.Request {
 	req := sip.NewRequest(method, recipment)
-	params := sip.NewParams()
-	params["branch"] = sip.GenerateBranch()
+	var params sip.HeaderParams
+	params.Add("branch", sip.GenerateBranch())
 	req.AppendHeader(&sip.ViaHeader{
 		ProtocolName:    "SIP",
 		ProtocolVersion: "2.0",
@@ -39,22 +40,18 @@ func createSimpleRequest(method sip.RequestMethod, sender sip.Uri, recipment sip
 	req.AppendHeader(&sip.FromHeader{
 		DisplayName: strings.ToUpper(sender.User),
 		Address: sip.Uri{
-			User:      sender.User,
-			Host:      sender.Host,
-			Port:      sender.Port,
-			UriParams: sip.NewParams(),
+			User: sender.User,
+			Host: sender.Host,
+			Port: sender.Port,
 		},
-		Params: sip.NewParams(),
 	})
 	req.AppendHeader(&sip.ToHeader{
 		DisplayName: strings.ToUpper(recipment.User),
 		Address: sip.Uri{
-			User:      recipment.User,
-			Host:      recipment.Host,
-			Port:      recipment.Port,
-			UriParams: sip.NewParams(),
+			User: recipment.User,
+			Host: recipment.Host,
+			Port: recipment.Port,
 		},
-		Params: sip.NewParams(),
 	})
 	callid := sip.CallIDHeader("gotest-" + time.Now().Format(time.RFC3339Nano))
 	req.AppendHeader(&callid)

--- a/sip/header_params_test.go
+++ b/sip/header_params_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSepToString(t *testing.T) {
-	hp := NewParams()
+	var hp HeaderParams
 	hp.Add("tag", "aaa")
 	hp.Add("branch", "bbb")
 
@@ -22,10 +22,10 @@ func TestSepToString(t *testing.T) {
 func BenchmarkHeaderParams(b *testing.B) {
 
 	testParams := func(b *testing.B, hp HeaderParams) {
-		hp = hp.Add("branch", "assadkjkgeijdas")
-		hp = hp.Add("received", "127.0.0.1")
-		hp = hp.Add("toremove", "removeme")
-		hp = hp.Remove("toremove")
+		hp.Add("branch", "assadkjkgeijdas")
+		hp.Add("received", "127.0.0.1")
+		hp.Add("toremove", "removeme")
+		hp.Remove("toremove")
 
 		if _, exists := hp.Get("received"); !exists {
 			b.Fatal("received does not exists")
@@ -36,7 +36,7 @@ func BenchmarkHeaderParams(b *testing.B) {
 			b.Fatal("Params empty")
 		}
 
-		if s != "branch=assadkjkgeijdas;received=127.0.0.1" && s != "received=127.0.0.1;branch=assadkjkgeijdas" {
+		if s != "branch=assadkjkgeijdas;received=127.0.0.1" {
 			b.Fatal("Bad parsing")
 		}
 	}

--- a/sip/parse_address.go
+++ b/sip/parse_address.go
@@ -9,7 +9,7 @@ import (
 type nameAddress struct {
 	displayName  string
 	uri          *Uri
-	headerParams HeaderParams
+	headerParams *HeaderParams
 }
 
 type addressFSM func(dispName *nameAddress, s string) (addressFSM, string, error)
@@ -17,7 +17,7 @@ type addressFSM func(dispName *nameAddress, s string) (addressFSM, string, error
 // ParseAddressValue parses an address - such as from a From, To, or
 // Contact header. It returns:
 // See RFC 3261 section 20.10 for details on parsing an address.
-func ParseAddressValue(addressText string, uri *Uri, headerParams HeaderParams) (displayName string, err error) {
+func ParseAddressValue(addressText string, uri *Uri, headerParams *HeaderParams) (displayName string, err error) {
 	if len(addressText) == 0 {
 		return "", errors.New("Empty Address")
 	}
@@ -196,8 +196,8 @@ func headerParserTo(headerName []byte, headerText string) (header Header, err er
 func parseToHeader(headerText string, h *ToHeader) error {
 	var err error
 
-	h.Params = NewParams()
-	h.DisplayName, err = ParseAddressValue(headerText, &h.Address, h.Params)
+	h.Params = nil
+	h.DisplayName, err = ParseAddressValue(headerText, &h.Address, &h.Params)
 	if err != nil {
 		return err
 	}
@@ -222,8 +222,8 @@ func headerParserFrom(headerName []byte, headerText string) (header Header, err 
 func parseFromHeader(headerText string, h *FromHeader) error {
 	var err error
 
-	h.Params = NewParams()
-	h.DisplayName, err = ParseAddressValue(headerText, &h.Address, h.Params)
+	h.Params = nil
+	h.DisplayName, err = ParseAddressValue(headerText, &h.Address, &h.Params)
 	// h.DisplayName, h.Address, h.Params, err = ParseAddressValue(headerText)
 	if err != nil {
 		return err
@@ -276,8 +276,8 @@ func parseContactHeader(headerText string, h *ContactHeader) error {
 	}
 
 	var e error
-	h.Params = NewParams()
-	h.DisplayName, e = ParseAddressValue(headerText[:endInd], &h.Address, h.Params)
+	h.Params = nil
+	h.DisplayName, e = ParseAddressValue(headerText[:endInd], &h.Address, &h.Params)
 	if e != nil {
 		return e
 	}
@@ -326,8 +326,8 @@ func headerParserReferredBy(headerName []byte, headerText string) (header Header
 func parseReferredByHeader(headerText string, h *ReferredByHeader) error {
 	var err error
 
-	h.Params = NewParams()
-	h.DisplayName, err = ParseAddressValue(headerText, &h.Address, h.Params)
+	h.Params = nil
+	h.DisplayName, err = ParseAddressValue(headerText, &h.Address, &h.Params)
 	if err != nil {
 		return err
 	}

--- a/sip/parse_address_test.go
+++ b/sip/parse_address_test.go
@@ -12,9 +12,9 @@ func TestParseAddressValue(t *testing.T) {
 		address := "\"Bob\" <sips:bob:password@127.0.0.1:5060;user=phone>;tag=1234"
 
 		uri := Uri{}
-		params := NewParams()
+		var params HeaderParams
 
-		displayName, err := ParseAddressValue(address, &uri, params)
+		displayName, err := ParseAddressValue(address, &uri, &params)
 
 		assert.Nil(t, err)
 		assert.Equal(t, "sips:bob:password@127.0.0.1:5060;user=phone", uri.String())
@@ -38,8 +38,8 @@ func TestParseAddressValue(t *testing.T) {
 	t.Run("no display name", func(t *testing.T) {
 		address := "sip:1215174826@222.222.222.222;tag=9300025590389559597"
 		uri := Uri{}
-		params := NewParams()
-		displayName, err := ParseAddressValue(address, &uri, params)
+		var params HeaderParams
+		displayName, err := ParseAddressValue(address, &uri, &params)
 		require.NoError(t, err)
 
 		assert.Equal(t, "", displayName)
@@ -51,22 +51,22 @@ func TestParseAddressValue(t *testing.T) {
 	t.Run("nil uri params", func(t *testing.T) {
 		address := "sip:1215174826@222.222.222.222:5066"
 		uri := Uri{}
-		params := NewParams()
-		displayName, err := ParseAddressValue(address, &uri, params)
+		var params HeaderParams
+		displayName, err := ParseAddressValue(address, &uri, &params)
 		require.NoError(t, err)
 
 		assert.Equal(t, "", displayName)
 		assert.Equal(t, "1215174826", uri.User)
 		assert.Equal(t, "222.222.222.222", uri.Host)
-		assert.Equal(t, HeaderParams{}, uri.UriParams)
+		assert.Equal(t, HeaderParams(nil), uri.UriParams)
 		assert.Equal(t, false, uri.IsEncrypted())
 	})
 
 	t.Run("wildcard", func(t *testing.T) {
 		address := "*"
 		uri := Uri{}
-		params := NewParams()
-		displayName, err := ParseAddressValue(address, &uri, params)
+		var params HeaderParams
+		displayName, err := ParseAddressValue(address, &uri, &params)
 		require.NoError(t, err)
 
 		assert.Equal(t, "", displayName)
@@ -77,8 +77,8 @@ func TestParseAddressValue(t *testing.T) {
 	t.Run("quoted-pairs", func(t *testing.T) {
 		address := "\"!\\\"#$%&/'()*+-.,0123456789:;<=>? @ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_'abcdefghijklmnopqrstuvwxyz{|}\" <sip:bob@127.0.0.1:5060;user=phone>;tag=1234"
 		uri := Uri{}
-		params := NewParams()
-		displayName, err := ParseAddressValue(address, &uri, params)
+		var params HeaderParams
+		displayName, err := ParseAddressValue(address, &uri, &params)
 		require.NoError(t, err)
 
 		assert.Equal(t, "sip:bob@127.0.0.1:5060;user=phone", uri.String())
@@ -105,9 +105,9 @@ func TestParseAddressBad(t *testing.T) {
 
 	t.Run("double ports in uri", func(t *testing.T) {
 		uri := Uri{}
-		params := NewParams()
+		var params HeaderParams
 		address := "<sip:127.0.0.1:5060:5060;lr;transport=udp>"
-		_, err := ParseAddressValue(address, &uri, params)
+		_, err := ParseAddressValue(address, &uri, &params)
 		require.Error(t, err)
 	})
 }
@@ -115,10 +115,10 @@ func TestParseAddressBad(t *testing.T) {
 func BenchmarkParseAddress(b *testing.B) {
 	address := "\"Bob\" <sips:bob:password@127.0.0.1:5060;user=phone>;tag=1234"
 	uri := Uri{}
-	params := NewParams()
+	var params HeaderParams
 
 	for i := 0; i < b.N; i++ {
-		displayName, err := ParseAddressValue(address, &uri, params)
+		displayName, err := ParseAddressValue(address, &uri, &params)
 		assert.Nil(b, err)
 		assert.Equal(b, "Bob", displayName)
 	}

--- a/sip/parse_params.go
+++ b/sip/parse_params.go
@@ -13,7 +13,7 @@ const (
 	paramsStateQuote
 )
 
-func UnmarshalHeaderParams(s string, seperator rune, ending rune, p HeaderParams) (n int, err error) {
+func UnmarshalHeaderParams(s string, seperator rune, ending rune, p *HeaderParams) (n int, err error) {
 	var start, sep, quote int = 0, 0, -1
 	state := paramsStateKey
 

--- a/sip/parse_uri.go
+++ b/sip/parse_uri.go
@@ -171,13 +171,13 @@ func uriStateUriParams(uri *Uri, s string) (uriFSM, string, error) {
 	var n int
 	var err error
 	if len(s) == 0 {
-		uri.UriParams = NewParams()
-		uri.Headers = NewParams()
+		uri.UriParams = nil
+		uri.Headers = nil
 		return nil, s, nil
 	}
 	uri.UriParams = NewParams()
 	// uri.UriParams, n, err = ParseParams(s, 0, ';', '?', true, true)
-	n, err = UnmarshalHeaderParams(s, ';', '?', uri.UriParams)
+	n, err = UnmarshalHeaderParams(s, ';', '?', &uri.UriParams)
 	if err != nil {
 		return nil, s, err
 	}
@@ -196,7 +196,7 @@ func uriStateUriParams(uri *Uri, s string) (uriFSM, string, error) {
 func uriStateHeaders(uri *Uri, s string) (uriFSM, string, error) {
 	var err error
 	// uri.Headers, _, err = ParseParams(s, 0, '&', 0, true, false)
-	uri.Headers = NewParams()
-	_, err = UnmarshalHeaderParams(s, '&', 0, uri.Headers)
+	uri.Headers = nil
+	_, err = UnmarshalHeaderParams(s, '&', 0, &uri.Headers)
 	return nil, s, err
 }

--- a/sip/parse_via.go
+++ b/sip/parse_via.go
@@ -20,7 +20,7 @@ func headerParserVia(headerName []byte, headerText string) (
 // these should not be treated as separate logical Via headers, but as multiple values on a single
 // Via header.
 func parseViaHeader(headerText string, h *ViaHeader) error {
-	h.Params = NewParams()
+	h.Params = nil
 
 	state := viaStateProtocol
 	str := headerText
@@ -108,13 +108,13 @@ func viaStateParams(h *ViaHeader, s string) (viaFSM, int, error) {
 	var err error
 	coma := strings.IndexRune(s, ',')
 	if coma > 0 {
-		_, err = UnmarshalHeaderParams(s[:coma], ';', ',', h.Params)
+		_, err = UnmarshalHeaderParams(s[:coma], ';', ',', &h.Params)
 		if err != nil {
 			return nil, 0, err
 		}
 		return viaStateProtocol, coma, errComaDetected(coma)
 	}
 
-	_, err = UnmarshalHeaderParams(s, ';', '\r', h.Params)
+	_, err = UnmarshalHeaderParams(s, ';', '\r', &h.Params)
 	return nil, 0, err
 }

--- a/sip/parser_test.go
+++ b/sip/parser_test.go
@@ -17,10 +17,10 @@ import (
 func TestUnmarshalParams(t *testing.T) {
 	s := "transport=tls;lr"
 	params := HeaderParams{}
-	UnmarshalHeaderParams(s, ';', '?', params)
+	UnmarshalHeaderParams(s, ';', '?', &params)
 	assert.Equal(t, 2, len(params))
-	assert.Equal(t, "tls", params["transport"])
-	assert.Equal(t, "", params["lr"])
+	assert.Equal(t, "tls", params.GetOr("transport", ""))
+	assert.Equal(t, "", params.GetOr("lr", "<missing>"))
 }
 
 func testParseHeader(t *testing.T, parser *Parser, header string) Header {
@@ -128,7 +128,7 @@ func TestParseHeaders(t *testing.T) {
 
 		for header, expected := range map[string]contactFields{
 			"Contact: <sip:2000@dkanrjsk.invalid>;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:a369bd8d-f310-4a95-8328-98c7ed3d5439>\";expires=300": {
-				address: "sip:2000@dkanrjsk.invalid", headers: map[string]string{"+sip.ice": "", "reg-id": "1", "+sip.instance": "\"<urn:uuid:a369bd8d-f310-4a95-8328-98c7ed3d5439>\"", "expires": "300"}},
+				address: "sip:2000@dkanrjsk.invalid", headers: HeaderParams{{"+sip.ice", ""}, {"reg-id", "1"}, {"+sip.instance", "\"<urn:uuid:a369bd8d-f310-4a95-8328-98c7ed3d5439>\""}, {"expires", "300"}}},
 			// "m: <sip:test@10.5.0.1:50267;transport=TCP;ob>;reg-id=1;+instance=\"<urn:uuid:00000000-0000-0000-0000-0000eb83488d>\"": {
 			// 	address: "sip:test@10.5.0.1:50267;transport=TCP;ob", headers: map[string]string{"reg-id": "1", "+instance": "\"<urn:uuid:00000000-0000-0000-0000-0000eb83488d>\""}},
 		} {
@@ -392,12 +392,12 @@ func TestParseResponse(t *testing.T) {
 
 	// Make sure via ref is correct set
 	via := r.Via()
-	assert.Equal(t, "z9hG4bK.VYWrxJJyeEJfngAjKXELr8aPYuX8tR22", via.Params["branch"])
+	assert.Equal(t, "z9hG4bK.VYWrxJJyeEJfngAjKXELr8aPYuX8tR22", via.Params.GetOr("branch", ""))
 
 	// Check all vias branch
 	vias := r.GetHeaders("via")
-	assert.Equal(t, "z9hG4bK.VYWrxJJyeEJfngAjKXELr8aPYuX8tR22", vias[0].(*ViaHeader).Params["branch"])
-	assert.Equal(t, "z9hG4bK-543537-1-0", vias[1].(*ViaHeader).Params["branch"])
+	assert.Equal(t, "z9hG4bK.VYWrxJJyeEJfngAjKXELr8aPYuX8tR22", vias[0].(*ViaHeader).Params.GetOr("branch", ""))
+	assert.Equal(t, "z9hG4bK-543537-1-0", vias[1].(*ViaHeader).Params.GetOr("branch", ""))
 	// Check no comma present
 	assert.False(t, strings.Contains(vias[1].String(), ","))
 

--- a/sip/response.go
+++ b/sip/response.go
@@ -240,8 +240,8 @@ func NewResponseFromRequest(
 		CopyHeaders("Timestamp", req, res)
 	default:
 		if h := res.To(); h != nil {
-			if _, ok := h.Params["tag"]; !ok {
-				h.Params["tag"] = uuid.NewString()
+			if !h.Params.Has("tag") {
+				h.Params.Add("tag", uuid.NewString())
 			}
 		}
 	}

--- a/sip/sip_test.go
+++ b/sip/sip_test.go
@@ -23,8 +23,8 @@ func BenchmarkGenerateBranch(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		val := GenerateBranch()
-		if len(val) != 32+len(RFC3261BranchMagicCookie)+1 {
-			b.Fatal("wrong number of bytes")
+		if len(val) != 16+len(RFC3261BranchMagicCookie)+1 {
+			b.Fatal("wrong number of bytes: " + val)
 		}
 	}
 }
@@ -33,8 +33,8 @@ func BenchmarkGenerateBranch16(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		val := GenerateBranchN(16)
-		if len(val) != 32+len(RFC3261BranchMagicCookie)+1 {
-			b.Fatal("wrong number of bytes")
+		if len(val) != 16+len(RFC3261BranchMagicCookie)+1 {
+			b.Fatal("wrong number of bytes: " + val)
 		}
 	}
 }

--- a/sip/transport_layer_test.go
+++ b/sip/transport_layer_test.go
@@ -18,7 +18,7 @@ func TestTransportLayerClosing(t *testing.T) {
 		t.Run(tran, func(t *testing.T) {
 			tp := NewTransportLayer(net.DefaultResolver, NewParser(), nil)
 			req := NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-			req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0, Params: NewParams()})
+			req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0})
 
 			conn, err := tp.ClientRequestConnection(context.TODO(), req)
 			require.NoError(t, err)
@@ -43,13 +43,13 @@ func TestTransportLayerClientConnectionReuse(t *testing.T) {
 
 	t.Run("Default", func(t *testing.T) {
 		req := NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0})
 
 		conn, err := tp.ClientRequestConnection(context.TODO(), req)
 		require.NoError(t, err)
 
 		req = NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0})
 
 		conn2, err := tp.ClientRequestConnection(context.TODO(), req)
 		require.NoError(t, err)
@@ -59,14 +59,14 @@ func TestTransportLayerClientConnectionReuse(t *testing.T) {
 
 	t.Run("WithClientHostPort", func(t *testing.T) {
 		req := NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "localhost", Port: 12345, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "localhost", Port: 12345})
 		req.Laddr = testCreateAddr(t, "127.0.0.1:12345")
 
 		conn, err := tp.ClientRequestConnection(context.TODO(), req)
 		require.NoError(t, err)
 
 		req = NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "localhost", Port: 12345, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "localhost", Port: 12345})
 		req.Laddr = testCreateAddr(t, "127.0.0.1:12345")
 
 		conn2, err := tp.ClientRequestConnection(context.TODO(), req)
@@ -75,7 +75,7 @@ func TestTransportLayerClientConnectionReuse(t *testing.T) {
 
 		// Now same destination but forcing port
 		req = NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 9876, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 9876})
 		req.Laddr = testCreateAddr(t, "127.0.0.1:9876")
 		conn3, err := tp.ClientRequestConnection(context.TODO(), req)
 
@@ -85,7 +85,7 @@ func TestTransportLayerClientConnectionReuse(t *testing.T) {
 
 	testParallel := func(t *testing.T, transport string) {
 		req := NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0})
 		req.SetTransport(transport)
 		connections := sync.Map{}
 		wg := sync.WaitGroup{}
@@ -143,13 +143,13 @@ func TestTransportLayerClientConnectionNoReuse(t *testing.T) {
 
 	t.Run("Default", func(t *testing.T) {
 		req := NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0})
 
 		conn, err := tp.ClientRequestConnection(context.TODO(), req)
 		require.NoError(t, err)
 
 		req = NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0})
 
 		conn2, err := tp.ClientRequestConnection(context.TODO(), req)
 		require.NoError(t, err)
@@ -159,14 +159,14 @@ func TestTransportLayerClientConnectionNoReuse(t *testing.T) {
 
 	t.Run("WithClientHostPort", func(t *testing.T) {
 		req := NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 12345, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 12345})
 		req.Laddr = testCreateAddr(t, "127.0.0.1:12345")
 
 		conn, err := tp.ClientRequestConnection(context.TODO(), req)
 		require.NoError(t, err)
 
 		req = NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 12345, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 12345})
 		req.Laddr = testCreateAddr(t, "127.0.0.1:12345")
 
 		conn2, err := tp.ClientRequestConnection(context.TODO(), req)
@@ -175,7 +175,7 @@ func TestTransportLayerClientConnectionNoReuse(t *testing.T) {
 
 		// Now same destination but forcing port
 		req = NewRequest(OPTIONS, Uri{Host: "localhost", Port: 5066})
-		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 9876, Params: NewParams()})
+		req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 9876})
 		req.Laddr = testCreateAddr(t, "127.0.0.1:9876")
 		conn3, err := tp.ClientRequestConnection(context.TODO(), req)
 		require.NoError(t, err)
@@ -192,7 +192,7 @@ func TestTransportLayerDefaultPort(t *testing.T) {
 		t.Run(tran, func(t *testing.T) {
 			tp := NewTransportLayer(net.DefaultResolver, NewParser(), nil)
 			req := NewRequest(OPTIONS, Uri{Host: "127.0.0.99"})
-			req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0, Params: NewParams()})
+			req.AppendHeader(&ViaHeader{Host: "127.0.0.1", Port: 0})
 
 			_, err := tp.ClientRequestConnection(context.TODO(), req)
 			require.NoError(t, err)


### PR DESCRIPTION
This changes switches from a map representation of header/URI params to a slice.

What changes:

- Parameters now preserve the order in which they appear in the original message.
- Parameters won't be shuffled around during encoding of SIP messages, which helps with testing.
- Zero value of `HeaderParams` is now safe to use, it doesn't require `NewParams()`.
- This change improves performance and reduces allocations (see below).
- Some minor changes needs to be done to update existing code (if it uses underlying maps directly).

## Benchmarking results

~25-30% faster header parsing, ~50-60% less allocations when parsing headers with params.

```
                               │   old.txt   │               new.txt                │
                               │   sec/op    │    sec/op     vs base                │
HeaderParams/MAP-12              160.0n ± 1%   112.2n ±  1%  -29.87% (p=0.000 n=10)
ParserHeaders/ViaHeader-12       191.6n ± 2%   138.0n ±  1%  -27.99% (p=0.000 n=10)
ParserHeaders/ToHeader-12        154.0n ± 1%   110.7n ±  1%  -28.14% (p=0.000 n=10)
ParserHeaders/FromHeader-12      153.5n ± 0%   109.9n ±  0%  -28.35% (p=0.000 n=10)
ParserHeaders/ContactHeader-12   177.3n ± 1%   136.1n ±  1%  -23.22% (p=0.000 n=10)
ParserHeaders/Route-12           295.5n ± 1%   247.1n ±  1%  -16.40% (p=0.001 n=10)

                               │    old.txt     │                 new.txt                 │
                               │      B/op      │     B/op      vs base                   │
HeaderParams/MAP-12                85.00 ± 1%      208.00 ± 0%  +144.71% (p=0.000 n=10)
ParserHeaders/ViaHeader-12         464.0 ± 0%       128.0 ± 0%   -72.41% (p=0.000 n=10)
ParserHeaders/ToHeader-12          304.0 ± 0%       208.0 ± 0%   -31.58% (p=0.000 n=10)
ParserHeaders/FromHeader-12        304.0 ± 0%       208.0 ± 0%   -31.58% (p=0.000 n=10)
ParserHeaders/ContactHeader-12     304.0 ± 0%       208.0 ± 0%   -31.58% (p=0.000 n=10)
ParserHeaders/Route-12             464.0 ± 0%       288.0 ± 0%   -37.93% (p=0.000 n=10)

                               │   old.txt    │               new.txt                │
                               │  allocs/op   │ allocs/op   vs base                  │
HeaderParams/MAP-12              3.000 ± 0%     4.000 ± 0%  +33.33% (p=0.000 n=10)
ParserHeaders/ViaHeader-12       4.000 ± 0%     2.000 ± 0%  -50.00% (p=0.000 n=10)
ParserHeaders/ToHeader-12        5.000 ± 0%     2.000 ± 0%  -60.00% (p=0.000 n=10)
ParserHeaders/FromHeader-12      5.000 ± 0%     2.000 ± 0%  -60.00% (p=0.000 n=10)
ParserHeaders/ContactHeader-12   5.000 ± 0%     2.000 ± 0%  -60.00% (p=0.000 n=10)
ParserHeaders/Route-12           4.000 ± 0%     3.000 ± 0%  -25.00% (p=0.000 n=10)
```

The `HeaderParams/MAP` shows the same performance improvement, but a bit more allocations. I believe this is caused by `NewParams()` allocating a bit more space when necessary to compensate for the real-world usage.

Typically, the number of parameters is limited by 4-5, which doesn't justify the overhead of Go maps, so these numbers make sense for the real SIP headers.

## Compatibility with existing code

Since the underlying type of `HeaderParams` is different, there are a couple of changes to the client code that must be done:

- If the code only uses existing functions (`NewParams`, `Get`, `Add`), then **no changes** are necessary!
- Initialization must be changed from `{"a":"1", "b":"2"}` to `{{"a","1"}, {"b":"2"}}`.
- Direct lookups via `params[k]` must be replaced with `params.Get(k)` or `params.GetOr(k, "")` (second one omits bool return).

There are some **side affects** that must be considered:

- `HeaderParams` is no longer a reference type, so passing it to functions and expecting changes to propagate requires an extra pointer.
- Methods like `Add` and `Remove` now require a pointer receiver. This should not require changes, since map was always a reference.