### PR TITLE
Fix ACK request address handling to preserve connection information

### DIFF
--- a/dialog_client.go
+++ b/dialog_client.go
@@ -542,6 +542,8 @@ func newAckRequestUAC(inviteRequest *sip.Request, inviteResponse *sip.Response, 
 	ackRequest.SetBody(body)
 	ackRequest.SetTransport(inviteRequest.Transport())
 	ackRequest.SetSource(inviteRequest.Source())
+	ackRequest.SetDestination(inviteRequest.Destination())
+	ackRequest.Laddr = inviteRequest.Laddr
 	return ackRequest
 }
 

--- a/sip/request.go
+++ b/sip/request.go
@@ -288,6 +288,9 @@ func newAckRequestNon2xx(inviteRequest *Request, inviteResponse *Response, body 
 	ackRequest.SetBody(body)
 	ackRequest.SetTransport(inviteRequest.Transport())
 	ackRequest.SetSource(inviteRequest.Source())
+	ackRequest.SetDestination(inviteRequest.Destination())
+	ackRequest.Laddr = inviteRequest.Laddr
+	ackRequest.raddr = inviteRequest.raddr
 	// if inviteResponse.IsSuccess() {
 	// 	// update branch, 2xx ACK is separate Tx
 	// 	viaHop := ackRequest.Via()


### PR DESCRIPTION
- Add Destination, Laddr to newAckRequestUAC for 2xx ACK responses
- Add Destination, Laddr, and raddr to newAckRequestNon2xx for non-2xx ACK responses
- Ensures ACK requests maintain same connection properties as original INVITE
- Fixes routing issues where ACK could be sent to wrong destination