### PR TITLE
Fix coupling between tx.Receive() and 200OK write. Fix ACK missed  wa…

### DIFF
--- a/sip/transaction_server_tx_fsm.go
+++ b/sip/transaction_server_tx_fsm.go
@@ -289,10 +289,7 @@ func (tx *ServerTx) actConfirm() fsmInput {
 
 	tx.mu.Unlock()
 
-	// ACK for a CANCEL-triggered 487 is not relevant to the application.
-	if tx.fsmErr != ErrTransactionCanceled {
-		tx.passAck()
-	}
+	tx.passAck()
 	return FsmInputNone
 }
 


### PR DESCRIPTION
Fix the tight coupling between tx.Receive() which fires the FSM and writes 487 synchronously and the subsequent 200 OK write means there's a window where the UA sees 487 first. Swapping the order is still the right fix

make acks buffered with size 1. The ACK gets queued without blocking