### PR TITLE
sip: send stateless 400 Bad Request for malformed requests

### DIFF
--- a/sip/transaction_layer.go
+++ b/sip/transaction_layer.go
@@ -215,7 +215,6 @@ func (txl *TransactionLayer) rejectMalformedRequest(req *Request, reason error) 
 	// Build a minimal 400 response from whatever headers the request has.
 	// NewResponseFromRequest safely skips nil CSeq, From, To, Call-ID.
 	res := NewResponseFromRequest(req, StatusBadRequest, "Bad Request", nil)
-	res.SetDestination(req.Source())
 
 	if err := txl.tpl.WriteMsg(res); err != nil {
 		txl.log.Error("Failed to send stateless 400 for malformed request",

--- a/sip/transaction_layer.go
+++ b/sip/transaction_layer.go
@@ -162,6 +162,7 @@ func (txl *TransactionLayer) handleRequest(req *Request) error {
 		// For now we only match INVITE
 		key, err := makeServerTxKey(req, INVITE)
 		if err != nil {
+			txl.rejectMalformedRequest(req, err)
 			return fmt.Errorf("make key failed: %w", err)
 		}
 
@@ -186,10 +187,43 @@ func (txl *TransactionLayer) handleRequest(req *Request) error {
 
 	key, err := makeServerTxKey(req, "")
 	if err != nil {
+		txl.rejectMalformedRequest(req, err)
 		return fmt.Errorf("make key failed: %w", err)
 	}
 
 	return txl.serverTxRequest(req, key)
+}
+
+// rejectMalformedRequest sends a stateless 400 Bad Request response when a
+// request is too malformed to create a transaction (e.g. missing CSeq or Via).
+//
+// Per RFC 3261 Section 8.2:
+//
+//	If a UAS does not understand a header field in a request (that is,
+//	the header field is not defined in this specification or in any
+//	installed extensions), the server MUST ignore that header field and
+//	continue processing the message.
+//
+// And Section 16.3 (Request Validation):
+//
+//	If the request contains a malformed header field that the proxy
+//	requires, the proxy SHOULD return a 400 (Bad Request) response.
+//
+// Without this, the sender retransmits indefinitely because it never
+// receives any response.
+func (txl *TransactionLayer) rejectMalformedRequest(req *Request, reason error) {
+	// Build a minimal 400 response from whatever headers the request has.
+	// NewResponseFromRequest safely skips nil CSeq, From, To, Call-ID.
+	res := NewResponseFromRequest(req, StatusBadRequest, "Bad Request", nil)
+	res.SetDestination(req.Source())
+
+	if err := txl.tpl.WriteMsg(res); err != nil {
+		txl.log.Error("Failed to send stateless 400 for malformed request",
+			"error", err,
+			"reason", reason.Error(),
+			"req", req.StartLine(),
+		)
+	}
 }
 
 func (txl *TransactionLayer) serverTxRequest(req *Request, key string) error {

--- a/sip/transaction_layer_test.go
+++ b/sip/transaction_layer_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -68,6 +70,81 @@ func TestIntegrationTransactionLayerServerTx(t *testing.T) {
 	require.NotNil(t, tx)
 	tx.Terminate()
 	require.EqualValues(t, 0, len(txl.serverTransactions.items))
+}
+
+func TestTransactionLayerMalformedRequestStateless400(t *testing.T) {
+	if os.Getenv("TEST_INTEGRATION") == "" {
+		t.Skip("Use TEST_INTEGRATION env value to run this test")
+		return
+	}
+
+	// Listen on a UDP port to receive the stateless 400 response.
+	receiverAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	receiverConn, err := net.ListenUDP("udp", receiverAddr)
+	require.NoError(t, err)
+	defer receiverConn.Close()
+	receiverActualAddr := receiverConn.LocalAddr().String()
+
+	// Set up the transaction layer with a real transport.
+	tp := NewTransportLayer(net.DefaultResolver, NewParser(), nil)
+	txl := NewTransactionLayer(tp)
+
+	var handlerCalled int32
+	txl.OnRequest(func(req *Request, tx *ServerTx) {
+		atomic.AddInt32(&handlerCalled, 1)
+	})
+
+	// Create a UDP connection in the transport pool so WriteMsg can find it.
+	localAddr := "127.0.0.1:15071"
+	_, err = tp.udp.CreateConnection(
+		context.TODO(),
+		testCreateAddr(t, localAddr),
+		testCreateAddr(t, receiverActualAddr),
+		tp.handleMessage,
+	)
+	require.NoError(t, err)
+
+	// Build a malformed request: valid Via, From, To, Call-ID, but NO CSeq.
+	raw := strings.Join([]string{
+		"REGISTER sip:192.168.100.30:5060 SIP/2.0",
+		"Via: SIP/2.0/UDP " + receiverActualAddr + ";branch=z9hG4bK-test123",
+		"From: <sip:alice@example.com>;tag=from1",
+		"To: <sip:alice@example.com>",
+		"Call-ID: malformed-test-call-id",
+		"Content-Length: 0",
+		"",
+		"",
+	}, "\r\n")
+
+	msg, err := ParseMessage([]byte(raw))
+	require.NoError(t, err)
+
+	req := msg.(*Request)
+	req.SetTransport("UDP")
+	req.SetSource(receiverActualAddr)
+
+	// handleRequest should return an error because CSeq is missing.
+	err = txl.handleRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CSeq")
+
+	// The request handler should NOT have been called.
+	assert.EqualValues(t, 0, atomic.LoadInt32(&handlerCalled))
+
+	// Read the stateless 400 response that should have been sent.
+	buf := make([]byte, 4096)
+	receiverConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, readErr := receiverConn.ReadFromUDP(buf)
+	require.NoError(t, readErr, "expected to receive a stateless 400 response")
+
+	respMsg, err := ParseMessage(buf[:n])
+	require.NoError(t, err)
+
+	resp, ok := respMsg.(*Response)
+	require.True(t, ok, "expected a SIP response")
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, "Bad Request", resp.Reason)
 }
 
 func TestTransactionLayerClientTx(t *testing.T) {


### PR DESCRIPTION
## Problem

When the transaction layer receives a request with missing mandatory headers (e.g. `CSeq`), `makeServerTxKey` fails and the request is silently dropped. The sender never receives a response and retransmits indefinitely, flooding server logs with errors like:

    Server tx failed to handle request: make key failed: 'CSeq' header not found

## Fix

Per RFC 3261 §16.3, a proxy that receives a request with a malformed required header SHOULD return a 400 Bad Request response.

Adds a `rejectMalformedRequest` helper that sends a stateless 400 Bad Request via the transport layer when transaction key creation fails. This covers both regular requests and CANCEL matching.

`NewResponseFromRequest` already handles nil CSeq, From, To, and Call-ID gracefully by skipping them, so the response is safe to build from a partially malformed request.

## Test

Integration test `TestTransactionLayerMalformedRequestStateless400` sends a REGISTER missing CSeq over UDP and verifies that a 400 Bad Request response is received instead of silence.