### PR TITLE
fix(sip): validate CSeq method matches request line per RFC 3261 §8.1.1.5

### DIFF
--- a/sip/transaction.go
+++ b/sip/transaction.go
@@ -313,6 +313,14 @@ func makeServerTxKey(msg Message, asMethod RequestMethod) (string, error) {
 	if cseq == nil {
 		return "", fmt.Errorf("'CSeq' header not found in message '%s'", messageShortString(msg))
 	}
+
+	// RFC 3261 §8.1.1.5: CSeq method MUST match the request line method.
+	if req, ok := msg.(*Request); ok {
+		if req.Method != cseq.MethodName {
+			return "", fmt.Errorf("'CSeq' method %q does not match request method %q in message '%s'", cseq.MethodName, req.Method, messageShortString(msg))
+		}
+	}
+
 	method := cseq.MethodName
 	if method == ACK {
 		method = INVITE

--- a/sip/transaction_layer_test.go
+++ b/sip/transaction_layer_test.go
@@ -147,6 +147,82 @@ func TestTransactionLayerMalformedRequestStateless400(t *testing.T) {
 	assert.Equal(t, "Bad Request", resp.Reason)
 }
 
+func TestTransactionLayerCSeqMethodMismatch(t *testing.T) {
+	if os.Getenv("TEST_INTEGRATION") == "" {
+		t.Skip("Use TEST_INTEGRATION env value to run this test")
+		return
+	}
+
+	// Listen on a UDP port to receive the stateless 400 response.
+	receiverAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	receiverConn, err := net.ListenUDP("udp", receiverAddr)
+	require.NoError(t, err)
+	defer receiverConn.Close()
+	receiverActualAddr := receiverConn.LocalAddr().String()
+
+	// Set up the transaction layer with a real transport.
+	tp := NewTransportLayer(net.DefaultResolver, NewParser(), nil)
+	txl := NewTransactionLayer(tp)
+
+	var handlerCalled int32
+	txl.OnRequest(func(req *Request, tx *ServerTx) {
+		atomic.AddInt32(&handlerCalled, 1)
+	})
+
+	// Create a UDP connection in the transport pool so WriteMsg can find it.
+	localAddr := "127.0.0.1:15072"
+	_, err = tp.udp.CreateConnection(
+		context.TODO(),
+		testCreateAddr(t, localAddr),
+		testCreateAddr(t, receiverActualAddr),
+		tp.handleMessage,
+	)
+	require.NoError(t, err)
+
+	// Build a malformed request: CSeq method mismatch method in Request Line.
+	raw := strings.Join([]string{
+		"REGISTER sip:192.168.100.30:5060 SIP/2.0",
+		"Via: SIP/2.0/UDP " + receiverActualAddr + ";branch=z9hG4bK-test123",
+		"From: <sip:alice@example.com>;tag=from1",
+		"To: <sip:alice@example.com>",
+		"Call-ID: malformed-test-call-id",
+		"Content-Length: 0",
+		"Cseq: 1 INVITE", // INVITE method for REGISTER request
+		"",
+		"",
+	}, "\r\n")
+
+	msg, err := ParseMessage([]byte(raw))
+	require.NoError(t, err)
+
+	req := msg.(*Request)
+	req.SetTransport("UDP")
+	req.SetSource(receiverActualAddr)
+
+	// handleRequest should return an error because CSeq method does not match Request Line method.
+	err = txl.handleRequest(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CSeq")
+
+	// The request handler should NOT have been called.
+	assert.EqualValues(t, 0, atomic.LoadInt32(&handlerCalled))
+
+	// Read the stateless 400 response that should have been sent.
+	buf := make([]byte, 4096)
+	receiverConn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, readErr := receiverConn.ReadFromUDP(buf)
+	require.NoError(t, readErr, "expected to receive a stateless 400 response")
+
+	respMsg, err := ParseMessage(buf[:n])
+	require.NoError(t, err)
+
+	resp, ok := respMsg.(*Response)
+	require.True(t, ok, "expected a SIP response")
+	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, "Bad Request", resp.Reason)
+}
+
 func TestTransactionLayerClientTx(t *testing.T) {
 	if os.Getenv("TEST_INTEGRATION") == "" {
 		t.Skip("Use TEST_INTEGRATION env value to run this test")

--- a/sip/utils_test.go
+++ b/sip/utils_test.go
@@ -28,7 +28,7 @@ func testCreateRequest(t testing.TB, method string, targetSipUri string, transpo
 		"From: \"Alice\" <sip:alice@" + fromAddr + ">;tag=" + ftag,
 		"To: \"Bob\" <" + targetSipUri + ">",
 		"Call-ID: " + callid,
-		"CSeq: 1 INVITE",
+		"CSeq: 1 " + method, // make sure method in CSeq matches method in Request Line
 		"Content-Length: 0",
 		"",
 		"",


### PR DESCRIPTION
## Summary

Adds RFC 3261 §8.1.1.5 validation: the method in the `CSeq` header of a request must match the method on the request line. Mismatched requests are rejected with a stateless `400 Bad Request` via the existing malformed-request path.

## Motivation

Per [RFC 3261 §8.1.1.5](https://datatracker.ietf.org/doc/html/rfc3261#section-8.1.1.5):

>  The method MUST match that of the request.

## Changes

### `sip/transaction.go`
Added the validation inside `makeServerTxKey`. This is the natural location because:
- It is called for every incoming server-side request before transaction matching.
- It already returns errors that route directly into `rejectMalformedRequest`, which sends the stateless 400.
- The CSeq method is used to build the transaction key, so validating it before use is cohesive.
- The `*Request` type assertion guards against running this check on `*Response` (where CSeq method legitimately reflects the original request method).

### `sip/transaction_layer_test.go`
Added integration test `TestTransactionLayerCSeqMethodMismatch` that:
- Sends a `REGISTER` request with `CSeq: 1 INVITE`.
- Asserts `handleRequest` returns an error referencing `CSeq`.
- Asserts the request handler is **not** invoked.
- Asserts a `400 Bad Request` response is delivered to the sender via UDP.

### `sip/utils_test.go`
Fixed a latent bug in the `testCreateRequest` helper: it hardcoded `CSeq: 1 INVITE` regardless of the `method` argument. The new validation correctly flagged this as malformed in `TestIntegrationTransactionLayerServerTx`, which calls the helper with `OPTIONS`. The helper now uses `"CSeq: 1 " + method`.


## Test Plan

- [x] `go test ./sip/` — full unit test suite passes.
- [x] `TEST_INTEGRATION=1 go test ./sip/` — full suite including integration tests passes.
- [x] New test `TestTransactionLayerCSeqMethodMismatch` passes and verifies the 400 round-trip.
- [x] Existing `TestIntegrationTransactionLayerServerTx` continues to pass after the helper fix.
- [x] No regressions in transaction-layer tests (`TestClientTransactionInviteFSM`, `TestServerTransactionFSM`, `TestServerTransactionFSMInvite`, etc.).

