### PR TITLE
fix(parse_via): handle IPv6 host literals in Via header parsing

### DIFF
--- a/sip/parse_via.go
+++ b/sip/parse_via.go
@@ -71,6 +71,52 @@ func viaStateProtocolTransport(h *ViaHeader, s string) (viaFSM, int, error) {
 }
 
 func viaStateHost(h *ViaHeader, s string) (viaFSM, int, error) {
+	// IPv6 host literal: "[addr]" with optional ":port" and ";params".
+	// The colons inside the IPv6 literal must not be confused with the
+	// host:port separator, so this case is handled before the generic
+	// colon-walking path below.
+	if len(s) > 0 && s[0] == '[' {
+		closeIdx := strings.Index(s, "]")
+		if closeIdx < 0 {
+			return nil, 0, errors.New("Malformed IPv6 host in Via header: no closing bracket")
+		}
+		// Store the bare IPv6 address without brackets to match the
+		// convention expected by uriIP() at serialization time.
+		h.Host = strings.TrimSpace(s[1:closeIdx])
+
+		rest := s[closeIdx+1:]
+		baseOff := closeIdx + 1
+		if len(rest) == 0 {
+			return nil, 0, nil
+		}
+		if rest[0] == ':' {
+			// Optional port follows the IPv6 literal.
+			endIdx := strings.IndexByte(rest, ';')
+			var portStr string
+			if endIdx < 0 {
+				portStr = rest[1:]
+			} else {
+				portStr = rest[1:endIdx]
+			}
+			port, err := strconv.Atoi(strings.TrimSpace(portStr))
+			if err != nil {
+				return nil, 0, nil
+			}
+			h.Port = port
+			if endIdx < 0 {
+				return nil, 0, nil
+			}
+			return viaStateParams, baseOff + endIdx + 1, nil
+		}
+		if rest[0] == ';' {
+			return viaStateParams, baseOff + 1, nil
+		}
+		// Unexpected character right after the IPv6 literal; bail
+		// without producing an error to keep behavior consistent with
+		// the legacy path which also returns nil on parse trouble.
+		return nil, 0, nil
+	}
+
 	var colonInd int
 	var endIndex int = len(s)
 	var err error

--- a/sip/parser_test.go
+++ b/sip/parser_test.go
@@ -65,6 +65,53 @@ func TestParseHeaders(t *testing.T) {
 			via := h.(*ViaHeader)
 			assert.Equal(t, "UDP", via.Transport)
 		})
+
+		t.Run("IPv6", func(t *testing.T) {
+			// Issue surfaced as livekit/sip#640: viaStateHost previously
+			// walked colons greedily and confused IPv6 separators with the
+			// host:port boundary, producing strconv.Atoi parse errors on
+			// IPv6 Via headers.
+			cases := []struct {
+				name      string
+				header    string
+				wantHost  string
+				wantPort  int
+				wantTrans string
+			}{
+				{
+					name:      "with_port",
+					header:    "Via: SIP/2.0/TCP [2001:67c:b0c:5::192]:5060;branch=z9hG4bKB5mrcD1BXK68a",
+					wantHost:  "2001:67c:b0c:5::192",
+					wantPort:  5060,
+					wantTrans: "TCP",
+				},
+				{
+					name:      "no_port",
+					header:    "Via: SIP/2.0/TCP [2001:67c:b0c:5::192];branch=z9hG4bKB5mrcD1BXK68a",
+					wantHost:  "2001:67c:b0c:5::192",
+					wantPort:  0,
+					wantTrans: "TCP",
+				},
+				{
+					name:      "loopback",
+					header:    "Via: SIP/2.0/UDP [::1]:5060;branch=z9hG4bK1234",
+					wantHost:  "::1",
+					wantPort:  5060,
+					wantTrans: "UDP",
+				},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					h := testParseHeader(t, parser, tc.header)
+					via, ok := h.(*ViaHeader)
+					require.True(t, ok, "expected ViaHeader, got %T", h)
+					assert.Equal(t, tc.wantHost, via.Host, "host mismatch")
+					assert.Equal(t, tc.wantPort, via.Port, "port mismatch")
+					assert.Equal(t, tc.wantTrans, via.Transport, "transport mismatch")
+				})
+			}
+		})
 	})
 
 	t.Run("ToHeader", func(t *testing.T) {


### PR DESCRIPTION
## What this fixes

`viaStateHost` in `sip/parse_via.go` previously walked all colons in a Via header host greedily, without IPv6 bracket awareness. For a header like:

```
Via: SIP/2.0/TCP [2001:67c:b0c:5::192];branch=z9hG4bKB5mrcD1BXK68a
```

the loop ends with `colonInd` pointing at the second `:` of `::`. `strconv.Atoi("192]")` then fails, the FSM bails out, and the SIP message is silently dropped at the transport layer.

## How it was diagnosed

Surfaced downstream as [livekit/sip#640](https://github.com/livekit/sip/issues/640) — IPv6 inbound INVITEs from FreeSWITCH (both UDP and TCP transports) failing with `strconv.Atoi: parsing "67c:b0c:5::192]:5060": invalid syntax: EOF on reading line`. Original report attributed the bug to livekit-sip's wrapping code, but tracing through the FSM character-by-character points cleanly at this function: livekit-sip's own `strconv.Atoi` calls are all in non-IPv6-relevant paths.

## Precedent

This is the same shape of bug that `parse_uri.go` had until [#226](https://github.com/emiago/sipgo/issues/226) was fixed in May 2025 by adding `uriStateHostIPV6` (`parse_uri.go:117`). The Via parser was missed in that round.

## The fix

Detect the leading `[` up front, capture everything up to the matching `]` as the host (stored without brackets to match `uriIP()`'s expectation at serialization — see `sip/utils.go:405`), then dispatch on whatever follows the bracket:

- `:port` — parse port via `strconv.Atoi` on the substring up to the next `;` or end-of-string
- `;params` — hand off to `viaStateParams` directly
- end-of-string — return cleanly with no params

Falls back to the original colon-walking path for non-IPv6 hosts unchanged. No regression risk for IPv4 / hostname callers.

## Diff shape

```
 sip/parse_via.go   | +46
 sip/parser_test.go | +47
```

All net additions. The only change to `parse_via.go:viaStateHost` is a guard at the top that handles the IPv6 bracket case before the existing colon-walking logic; non-IPv6 inputs hit the original code path unmodified.

## Test coverage

Added an `IPv6` subtest under `TestParseHeaders/ViaHeader` covering three real-world shapes:

| Case | Header | Expected |
|---|---|---|
| `with_port` | `[2001:67c:b0c:5::192]:5060;branch=...` | host=`2001:67c:b0c:5::192`, port=5060 |
| `no_port` | `[2001:67c:b0c:5::192];branch=...` (the livekit/sip#640 case) | host=`2001:67c:b0c:5::192`, port=0 |
| `loopback` | `[::1]:5060;branch=...` | host=`::1`, port=5060 |

Without the fix, the `no_port` case fails (`host=""`); with the fix, all three pass.

## Verification

- `go test ./sip/ -run "TestParseHeaders" -count=1` — **PASS** (all subtests including the new `IPv6` block)
- `go test ./sip/ -count=1` — **PASS** (full sip package: parser, headers, transactions, fuzz, stream)
- I deliberately reverted the fix and re-ran to confirm `no_port` fails on the unfixed parser before applying — empirical regression-test discipline

The integration test failure at the repo root (`server_integration_test.go:36: testdata/certs/client.crt: no matching files found`) is pre-existing — `//go:embed` fails on missing test certs that aren't checked into the repo. Unrelated to this PR.

## Credit

Original report by @arsenieciprian on [livekit/sip#640](https://github.com/livekit/sip/issues/640). They did the empirical work to demonstrate the bug across UDP and TCP transports — the FSM trace and fix shape here is downstream of that report.