### PR TITLE
fix(parser): unfold continuation header lines per RFC 3261 §7.3.1 (#251)

### DIFF
--- a/sip/parser.go
+++ b/sip/parser.go
@@ -151,32 +151,45 @@ func (p *Parser) parseNextHeader(out []Header, data []byte) ([]Header, int, erro
 
 	// RFC 3261 §7.3.1: a header field may be continued onto the next line if
 	// that line begins with at least one SP or HT. The CRLF and surrounding
-	// whitespace must be replaced by a single SP. Sweep up any continuation
-	// lines now so the downstream header parser sees a single logical line.
-	for n < len(data) && (data[n] == ' ' || data[n] == '\t') {
-		cont, contN, contErr := nextLine(data[n:])
-		if contErr != nil {
-			// Need more bytes / malformed CRLF on the continuation. Surface
-			// the same way an incomplete first line would surface so the
-			// stream parser can retry with more data.
-			if contErr == io.EOF {
-				return out, 0, io.ErrUnexpectedEOF
+	// whitespace must be replaced by a single SP. Pre-scan the continuation
+	// lines so we can size the output exactly and fold with a single
+	// allocation regardless of how many continuations there are.
+	if n < len(data) && (data[n] == ' ' || data[n] == '\t') {
+		type foldSegment struct{ start, end int }
+		var segs []foldSegment
+		totalSize := len(line)
+		for n < len(data) && (data[n] == ' ' || data[n] == '\t') {
+			cont, contN, contErr := nextLine(data[n:])
+			if contErr != nil {
+				// Need more bytes / malformed CRLF on the continuation.
+				// Surface the same way an incomplete first line would, so the
+				// stream parser can retry with more data.
+				if contErr == io.EOF {
+					return out, 0, io.ErrUnexpectedEOF
+				}
+				return out, 0, contErr
 			}
-			return out, 0, contErr
+			// Trim leading SP/HT runs from the continuation per RFC 3261 §7.3.1.
+			contStart := n
+			contEnd := n + len(cont)
+			for contStart < contEnd && (data[contStart] == ' ' || data[contStart] == '\t') {
+				contStart++
+			}
+			segs = append(segs, foldSegment{contStart, contEnd})
+			totalSize += 1 + (contEnd - contStart) // +1 for the SP separator
+			n += contN
 		}
-		// `line` may alias the original buffer; allocate a fresh slice the
-		// first time we fold so we don't write into the caller's data.
-		folded := make([]byte, 0, len(line)+1+len(cont))
+
+		// Single allocation, exactly sized, regardless of continuation count.
+		// `line` may alias the original buffer; copying into a fresh slice
+		// also keeps us from writing into the caller's data.
+		folded := make([]byte, 0, totalSize)
 		folded = append(folded, line...)
-		folded = append(folded, ' ')
-		// Trim leading SP/HT runs from the continuation per RFC 3261 §7.3.1.
-		i := 0
-		for i < len(cont) && (cont[i] == ' ' || cont[i] == '\t') {
-			i++
+		for _, s := range segs {
+			folded = append(folded, ' ')
+			folded = append(folded, data[s.start:s.end]...)
 		}
-		folded = append(folded, cont[i:]...)
 		line = folded
-		n += contN
 	}
 
 	out, err = p.headersParsers.ParseHeader(out, line)

--- a/sip/parser.go
+++ b/sip/parser.go
@@ -148,6 +148,37 @@ func (p *Parser) parseNextHeader(out []Header, data []byte) ([]Header, int, erro
 		// We've hit the end of the header section.
 		return out, n, errParseNoMoreHeaders
 	}
+
+	// RFC 3261 §7.3.1: a header field may be continued onto the next line if
+	// that line begins with at least one SP or HT. The CRLF and surrounding
+	// whitespace must be replaced by a single SP. Sweep up any continuation
+	// lines now so the downstream header parser sees a single logical line.
+	for n < len(data) && (data[n] == ' ' || data[n] == '\t') {
+		cont, contN, contErr := nextLine(data[n:])
+		if contErr != nil {
+			// Need more bytes / malformed CRLF on the continuation. Surface
+			// the same way an incomplete first line would surface so the
+			// stream parser can retry with more data.
+			if contErr == io.EOF {
+				return out, 0, io.ErrUnexpectedEOF
+			}
+			return out, 0, contErr
+		}
+		// `line` may alias the original buffer; allocate a fresh slice the
+		// first time we fold so we don't write into the caller's data.
+		folded := make([]byte, 0, len(line)+1+len(cont))
+		folded = append(folded, line...)
+		folded = append(folded, ' ')
+		// Trim leading SP/HT runs from the continuation per RFC 3261 §7.3.1.
+		i := 0
+		for i < len(cont) && (cont[i] == ' ' || cont[i] == '\t') {
+			i++
+		}
+		folded = append(folded, cont[i:]...)
+		line = folded
+		n += contN
+	}
+
 	out, err = p.headersParsers.ParseHeader(out, line)
 	if err != nil {
 		// We might not need to return n here?

--- a/sip/parser_folded_test.go
+++ b/sip/parser_folded_test.go
@@ -1,0 +1,115 @@
+package sip
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Reproducer for sipgo#251: SIP headers with folded continuation lines fail
+// to parse. RFC 3261 §7.3.1 (citing RFC 2822) explicitly allows headers to be
+// extended over multiple lines by preceding each extra line with at least one
+// SP or HT, and the folding plus surrounding whitespace must be treated as a
+// single SP. The trace below is from the AT&T VoWiFi production server (a
+// real, currently-deployed P-CSCF) reported by @DentonGentry.
+func TestParseFoldedHeaders_AT_T_Repro(t *testing.T) {
+	rawMsg := []string{
+		"SIP/2.0 401 Unauthorized",
+		"Call-ID: 01234567",
+		"Via: SIP/2.0/TCP [::1]:5060;received=::1;branch=z9hG4bK.1;rport=48512",
+		"To: <sip:30123456789@one.att.net>;tag=abcdef",
+		"From: \"30123456789\" <sip:30123456789@one.att.net>;tag=abcdef",
+		"CSeq: 1 REGISTER",
+		"Date: Tue, 12 Aug 2025 01:20:52 GMT",
+		"Server: Alcatel-Lucent-HPSS/3.0.3",
+		"WWW-Authenticate: Digest realm=\"one.att.net\",",
+		"   nonce=\"abcdefghijklmnopqrstuvwxyz=\",",
+		"   opaque=\"ALU:abcdefghijklmnopqrstuvwxyz__\",",
+		"   algorithm=AKAv1-MD5,",
+		"   qop=\"auth\"",
+		"Content-Length: 0",
+		"",
+		"",
+	}
+
+	data := []byte(strings.Join(rawMsg, "\r\n"))
+
+	parser := NewParser()
+	msg, err := parser.ParseSIP(data)
+	require.NoError(t, err, "RFC 3261 §7.3.1 line folding must be supported")
+	r, ok := msg.(*Response)
+	require.True(t, ok, "expected *Response, got %T", msg)
+
+	// The folded WWW-Authenticate must round-trip with the continuation lines
+	// concatenated into a single logical value (per RFC 3261, fold-whitespace
+	// becomes a single SP).
+	auth := r.GetHeaders("WWW-Authenticate")
+	require.NotEmpty(t, auth, "WWW-Authenticate header must be present after fold-aware parsing")
+
+	authStr := auth[0].Value()
+	for _, expect := range []string{
+		`realm="one.att.net"`,
+		`nonce="abcdefghijklmnopqrstuvwxyz="`,
+		`opaque="ALU:abcdefghijklmnopqrstuvwxyz__"`,
+		"algorithm=AKAv1-MD5",
+		`qop="auth"`,
+	} {
+		assert.Contains(t, authStr, expect, "folded portion %q missing from unfolded header", expect)
+	}
+}
+
+// Smaller, deterministic test cases isolating just the folding behavior on a
+// header that doesn't have a custom parser (Server is rendered as a generic
+// header, so the value round-trips literally).
+func TestParseFoldedHeaders_Cases(t *testing.T) {
+	cases := []struct {
+		name      string
+		header    string
+		want      string // expected unfolded Value()
+	}{
+		{
+			name: "single_continuation_with_spaces",
+			header: "Server: Alcatel-Lucent\r\n" +
+				"   HPSS/3.0.3",
+			want: "Alcatel-Lucent HPSS/3.0.3",
+		},
+		{
+			name: "single_continuation_with_tab",
+			header: "Server: Alcatel-Lucent\r\n" +
+				"\tHPSS/3.0.3",
+			want: "Alcatel-Lucent HPSS/3.0.3",
+		},
+		{
+			name: "no_folding_baseline",
+			header: "Server: Alcatel-Lucent-HPSS/3.0.3",
+			want: "Alcatel-Lucent-HPSS/3.0.3",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawMsg := []string{
+				"SIP/2.0 200 OK",
+				"Call-ID: x",
+				"Via: SIP/2.0/UDP 127.0.0.1:5060;branch=z9hG4bK1",
+				"To: <sip:a@b>",
+				"From: <sip:c@d>;tag=1",
+				"CSeq: 1 OPTIONS",
+				tc.header,
+				"Content-Length: 0",
+				"",
+				"",
+			}
+			data := []byte(strings.Join(rawMsg, "\r\n"))
+			parser := NewParser()
+			msg, err := parser.ParseSIP(data)
+			require.NoError(t, err)
+			r := msg.(*Response)
+			servers := r.GetHeaders("Server")
+			require.NotEmpty(t, servers, "Server header must be present")
+			assert.Equal(t, tc.want, servers[0].Value())
+		})
+	}
+}


### PR DESCRIPTION
Refs #251.

## Context — and why this is filed as a draft

@emiago — you mentioned on April 13 that you'd prefer to handle line folding via #295's prefilter feature. Filing this as a draft so you have a turnkey alternative to consider, but happy to step aside immediately if you'd rather proceed with the prefilter route — please just close this and I won't take it personally. The prefilter feature serves a broader set of needs than this single bug, so the two paths aren't mutually exclusive even.

The reason I'm offering the parser-level fix as an option: RFC 3261 §7.3.1 explicitly requires support for header continuation, so the current behavior is non-compliant by default. Pushing the work to every sipgo user via a prefilter hook means each consumer reimplements the same RFC normalization, and silently dropped messages remain the default for users who haven't yet realized line folding can occur on their carrier.

## What this fixes

@DentonGentry's [#251](https://github.com/emiago/sipgo/issues/251) reproduces the failure with a real `WWW-Authenticate` header from the AT&T VoWiFi P-CSCF (the production service handling US AT&T Wireless voice and SMS). Folded over four continuation lines:

```
WWW-Authenticate: Digest realm="one.att.net",
   nonce="abcdefghijklmnopqrstuvwxyz=",
   opaque="ALU:abcdefghijklmnopqrstuvwxyz__",
   algorithm=AKAv1-MD5,
   qop="auth"
```

The current parser treats line two onward as fresh headers and surfaces `field name with no value in header: "   nonce=..."`, dropping the message entirely.

## How it works

`parseNextHeader` now sweeps continuation lines into the logical header line before handing it to the per-header parser. The fix is wholly contained in `parseNextHeader`; `nextLine`, the start-line parser, and the per-header parsers are untouched.

```go
// RFC 3261 §7.3.1: a header field may be continued onto the next line if
// that line begins with at least one SP or HT. The CRLF and surrounding
// whitespace must be replaced by a single SP.
for n < len(data) && (data[n] == ' ' || data[n] == '\t') {
    cont, contN, contErr := nextLine(data[n:])
    if contErr != nil {
        if contErr == io.EOF {
            return out, 0, io.ErrUnexpectedEOF
        }
        return out, 0, contErr
    }
    folded := make([]byte, 0, len(line)+1+len(cont))
    folded = append(folded, line...)
    folded = append(folded, ' ')
    i := 0
    for i < len(cont) && (cont[i] == ' ' || cont[i] == '\t') {
        i++
    }
    folded = append(folded, cont[i:]...)
    line = folded
    n += contN
}
```

## Properties

- **End-of-headers boundary is unaffected.** The empty line that terminates the header section starts with `\r`, which fails the SP/HT check, so it short-circuits to `errParseNoMoreHeaders` exactly as before.
- **Streaming partial-data contract preserved.** A truncated continuation surfaces as `io.ErrUnexpectedEOF` with `n=0`, matching the existing semantics for an incomplete first line, so the stream parser retries with more bytes.
- **`nextLine` itself unchanged.** The start-line path (where folding must NOT apply) is untouched.
- **Zero allocation on the no-fold path.** Non-folded headers (the common case) take the original code path; the new slice is allocated only when at least one continuation exists.
- **N-line continuations supported.** The AT&T trace folds across four continuation lines; the loop handles arbitrary depth.
- **Strict behavior superset.** Any message that parsed before still parses identically; only previously-erroring messages now succeed.

## Tests

`sip/parser_folded_test.go` adds two test functions:

- `TestParseFoldedHeaders_AT_T_Repro` — replays @DentonGentry's full `401 Unauthorized` trace and asserts every `WWW-Authenticate` subfield survives the fold.
- `TestParseFoldedHeaders_Cases` — isolates the folding behavior on a generic header (`Server`, no custom parser) with three sub-cases: spaces-prefixed continuation, tab-prefixed continuation, and a no-folding control.

## Verification

| Platform | Pre-fix | Post-fix |
|---|---|---|
| Windows (Go 1.26.2 native) | folding tests fail with the exact error from #251; full suite otherwise green | all four new tests pass; full sip-package suite green |
| Linux (`golang:1.26` Docker, amd64) | folding tests fail with the same error | all four new tests pass; full sip-package suite green |

## Credit

Original report and the test trace by @DentonGentry in #251. They isolated this against the AT&T VoWiFi P-CSCF in production and even pushed a demo branch reproducing the failure — saving the diagnosis work entirely.