### PR TITLE
feat(client): add outbound proxy support via Route header

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/icholy/digest"
@@ -30,6 +31,11 @@ type Client struct {
 	log   *slog.Logger
 
 	connAddr sip.Addr
+
+	// outboundProxy, when non-nil, is auto-prepended as a loose Route on
+	// out-of-dialog requests built by this client. Stored atomically so
+	// SetOutboundProxy can race safely against in-flight requests.
+	outboundProxy atomic.Pointer[sip.Uri]
 
 	// TxRequester allows you to use your transaction requester instead default from transaction layer
 	// Useful only for testing
@@ -90,6 +96,68 @@ func WithClientNAT() ClientOption {
 		s.rport = true
 		return nil
 	}
+}
+
+// WithClientOutboundProxy sets a default outbound proxy for the client.
+// hostPort uses the standard "<host>:<port>" form, e.g.
+// "proxy.example.com:5080". transport is the SIP transport to reach the
+// proxy (e.g. "udp", "tcp", "tls", "ws"); pass "" to leave the transport
+// unset, in which case the request inherits the existing per-request
+// selection (Via / Recipient / UDP default).
+//
+// Each new request built by this client gets a loose-routing Route header
+// (RFC 3261 §16.12.1) pointing at this proxy when no Route header is already
+// present. That makes Request.Destination() resolve to the proxy host while
+// the Request-URI is left untouched. When transport is non-empty it is added
+// as a ;transport= URI param on the Route, so Request.Transport() and the
+// stamped Via reflect the proxy's transport. In-dialog requests already
+// carrying a Route from Record-Route are not modified.
+func WithClientOutboundProxy(hostPort, transport string) ClientOption {
+	return func(s *Client) error {
+		return s.SetOutboundProxy(hostPort, transport)
+	}
+}
+
+// SetOutboundProxy updates the client's outbound proxy at runtime. Pass an
+// empty hostPort to clear it. transport is normalized to lowercase and
+// stamped as a ;transport= URI param on the auto-injected Route; pass ""
+// to omit. Safe to call concurrently with in-flight requests; a swap is
+// observed by subsequent build calls only.
+func (c *Client) SetOutboundProxy(hostPort, transport string) error {
+	if hostPort == "" {
+		c.outboundProxy.Store(nil)
+		return nil
+	}
+	host, port, err := sip.ParseAddr(hostPort)
+	if err != nil {
+		return err
+	}
+	uri := &sip.Uri{Host: host, Port: port}
+	if transport != "" {
+		uri.UriParams = sip.NewParams()
+		uri.UriParams.Add("transport", sip.NetworkToLower(transport))
+	}
+	c.outboundProxy.Store(uri)
+	return nil
+}
+
+// OutboundProxy returns the configured outbound proxy as ("host:port",
+// transport). Both values are empty strings when no proxy is set; transport
+// alone may be empty when only host:port was configured.
+func (c *Client) OutboundProxy() (hostPort, transport string) {
+	p := c.outboundProxy.Load()
+	if p == nil {
+		return "", ""
+	}
+	if p.Port > 0 {
+		hostPort = fmt.Sprintf("%s:%d", p.Host, p.Port)
+	} else {
+		hostPort = p.Host
+	}
+	if p.UriParams != nil {
+		transport, _ = p.UriParams.Get("transport")
+	}
+	return hostPort, transport
 }
 
 // WithClientAddr is merge of WithClientHostname and WithClientPort
@@ -337,6 +405,20 @@ func clientRequestBuildReq(c *Client, req *sip.Request) error {
 	// the following header fields: To, From, CSeq, Call-ID, Max-Forwards,
 	// and Via;
 
+	proxy := c.outboundProxy.Load()
+	addProxyRoute := proxy != nil && req.Route() == nil
+
+	// When the proxy declares an explicit transport, surface it on the
+	// request before Via is stamped so Via and the connection picked by
+	// the transport layer agree with the proxy. When the proxy carries
+	// no transport, leave selection alone so Recipient ;transport= and
+	// any prior req.SetTransport call still drive the Via build.
+	if addProxyRoute && proxy.UriParams != nil && req.MessageData.Transport() == "" {
+		if t, ok := proxy.UriParams.Get("transport"); ok && t != "" {
+			req.SetTransport(sip.NetworkToUpper(t))
+		}
+	}
+
 	mustHeader := make([]sip.Header, 0, 6)
 	if v := req.Via(); v == nil {
 		// Multi VIA value must be manually added
@@ -400,6 +482,13 @@ func clientRequestBuildReq(c *Client, req *sip.Request) error {
 	}
 
 	req.PrependHeader(mustHeader...)
+
+	// Prepend the outbound proxy Route after Via so it does not shadow
+	// the Recipient transport hint at Via build time. Destination still
+	// follows the Route because Request.Destination() inspects it.
+	if addProxyRoute {
+		req.PrependHeader(buildLooseRoute(*proxy))
+	}
 
 	if req.Body() == nil {
 		req.SetBody(nil)
@@ -478,6 +567,40 @@ func clientRequestCreateVia(c *Client, r *sip.Request) *sip.ViaHeader {
 		}
 	}
 	return newvia
+}
+
+// ClientRequestAddRoute returns a ClientRequestOption that prepends a Route
+// header pointing at the given URI. This is the standard loose-routing
+// mechanism (RFC 3261 §16.12.1) for sending requests through an outbound
+// proxy: the Request-URI is left untouched, but Request.Destination() returns
+// the top Route URI when present, so the transport layer dispatches to the
+// proxy host instead of the Request-URI host.
+//
+// The "lr" parameter is added if not already set, marking the proxy as a
+// loose router. The caller-provided URI is cloned, so subsequent mutations to
+// the passed value do not leak into the request.
+//
+// For a client-wide default that auto-applies to every out-of-dialog
+// request, see WithClientOutboundProxy.
+func ClientRequestAddRoute(routeURI sip.Uri) ClientRequestOption {
+	return func(c *Client, r *sip.Request) error {
+		r.PrependHeader(buildLooseRoute(routeURI))
+		return nil
+	}
+}
+
+// buildLooseRoute clones uri and ensures it carries the "lr" param, then
+// wraps it in a RouteHeader. Used by both the per-request option and the
+// client-wide outbound proxy auto-injection.
+func buildLooseRoute(routeURI sip.Uri) *sip.RouteHeader {
+	uri := *routeURI.Clone()
+	if uri.UriParams == nil {
+		uri.UriParams = sip.NewParams()
+	}
+	if !uri.UriParams.Has("lr") {
+		uri.UriParams.Add("lr", "")
+	}
+	return &sip.RouteHeader{Address: uri}
 }
 
 // ClientRequestAddRecordRoute is option for adding record route header

--- a/client_test.go
+++ b/client_test.go
@@ -192,6 +192,240 @@ func TestClientRequestOptions(t *testing.T) {
 	assert.Len(t, res.GetHeaders("Via"), 1)
 }
 
+func TestClientRequestAddRoute(t *testing.T) {
+	ua, err := NewUA()
+	require.Nil(t, err)
+
+	c, err := NewClient(ua, WithClientHostname("10.0.0.0"))
+	require.Nil(t, err)
+
+	sender := sip.Uri{User: "alice", Host: "10.1.1.1", Port: 5060}
+	recipient := sip.Uri{User: "bob", Host: "10.2.2.2", Port: 5060}
+
+	t.Run("AddsLooseRouteHeader", func(t *testing.T) {
+		req := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		proxy := sip.Uri{Host: "proxy.example.com", Port: 5080}
+
+		err := ClientRequestAddRoute(proxy)(c, req)
+		require.Nil(t, err)
+
+		got := req.Route()
+		require.NotNil(t, got)
+		assert.Equal(t, "proxy.example.com", got.Address.Host)
+		assert.Equal(t, 5080, got.Address.Port)
+		assert.True(t, got.Address.UriParams.Has("lr"))
+
+		// Per RFC 3261, the request must be dispatched to the top Route URI,
+		// not to the Request-URI host.
+		assert.Equal(t, "proxy.example.com:5080", req.Destination())
+		assert.Equal(t, recipient.Host, req.Recipient.Host, "Request-URI must be unchanged")
+	})
+
+	t.Run("PreservesExistingLrParam", func(t *testing.T) {
+		req := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		params := sip.NewParams()
+		params.Add("lr", "")
+		params.Add("transport", "tcp")
+		proxy := sip.Uri{Host: "proxy.example.com", Port: 5080, UriParams: params}
+
+		err := ClientRequestAddRoute(proxy)(c, req)
+		require.Nil(t, err)
+
+		got := req.Route()
+		require.NotNil(t, got)
+		// Both params should be present and lr should not be duplicated.
+		assert.True(t, got.Address.UriParams.Has("lr"))
+		assert.Equal(t, "tcp", got.Address.UriParams.GetOr("transport", ""))
+		lrCount := 0
+		for _, p := range got.Address.UriParams {
+			if p.K == "lr" {
+				lrCount++
+			}
+		}
+		assert.Equal(t, 1, lrCount, "lr parameter must not be duplicated")
+	})
+
+	t.Run("ClonesCallerURI", func(t *testing.T) {
+		req := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		proxy := sip.Uri{Host: "proxy.example.com", Port: 5080}
+
+		err := ClientRequestAddRoute(proxy)(c, req)
+		require.Nil(t, err)
+
+		// Mutating the URI passed to the option must not affect the header.
+		proxy.Host = "tampered.example.com"
+		assert.Equal(t, "proxy.example.com", req.Route().Address.Host)
+	})
+}
+
+func TestClientOutboundProxy(t *testing.T) {
+	ua, err := NewUA()
+	require.Nil(t, err)
+
+	sender := sip.Uri{User: "alice", Host: "10.1.1.1", Port: 5060}
+	recipient := sip.Uri{User: "bob", Host: "10.2.2.2", Port: 5060}
+
+	t.Run("OptionInjectsRouteOnBuild", func(t *testing.T) {
+		c, err := NewClient(ua,
+			WithClientHostname("10.0.0.0"),
+			WithClientOutboundProxy("proxy.example.com:5080", ""),
+		)
+		require.Nil(t, err)
+		hp, tp := c.OutboundProxy()
+		assert.Equal(t, "proxy.example.com:5080", hp)
+		assert.Equal(t, "", tp)
+
+		req := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		require.Nil(t, clientRequestBuildReq(c, req))
+
+		got := req.Route()
+		require.NotNil(t, got)
+		assert.Equal(t, "proxy.example.com", got.Address.Host)
+		assert.Equal(t, 5080, got.Address.Port)
+		assert.True(t, got.Address.UriParams.Has("lr"))
+
+		// Destination must follow the proxy, not the Request-URI.
+		assert.Equal(t, "proxy.example.com:5080", req.Destination())
+		assert.Equal(t, recipient.Host, req.Recipient.Host)
+	})
+
+	t.Run("TransportStampedOnRouteAndVia", func(t *testing.T) {
+		c, err := NewClient(ua,
+			WithClientHostname("10.0.0.0"),
+			WithClientOutboundProxy("proxy.example.com:5080", "TCP"),
+		)
+		require.Nil(t, err)
+		hp, tp := c.OutboundProxy()
+		assert.Equal(t, "proxy.example.com:5080", hp)
+		assert.Equal(t, "tcp", tp, "transport must be normalized to lowercase")
+
+		// Build a request without an explicit transport: the proxy's hint
+		// must drive both Via and Request.Transport().
+		req := sip.NewRequest(sip.INVITE, recipient)
+		require.Nil(t, clientRequestBuildReq(c, req))
+
+		assert.Equal(t, "tcp", req.Route().Address.UriParams.GetOr("transport", ""))
+		assert.Equal(t, "TCP", req.Transport(), "Route ;transport= must drive Request.Transport()")
+		assert.Equal(t, "TCP", req.Via().Transport, "Via must reflect the proxy's transport")
+	})
+
+	t.Run("RuntimeSetterAndClear", func(t *testing.T) {
+		c, err := NewClient(ua, WithClientHostname("10.0.0.0"))
+		require.Nil(t, err)
+		hp, _ := c.OutboundProxy()
+		assert.Equal(t, "", hp)
+
+		require.Nil(t, c.SetOutboundProxy("proxy.example.com:5080", "tls"))
+		hp, tp := c.OutboundProxy()
+		assert.Equal(t, "proxy.example.com:5080", hp)
+		assert.Equal(t, "tls", tp)
+
+		req := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		require.Nil(t, clientRequestBuildReq(c, req))
+		require.NotNil(t, req.Route())
+
+		require.Nil(t, c.SetOutboundProxy("", ""))
+		hp, tp = c.OutboundProxy()
+		assert.Equal(t, "", hp)
+		assert.Equal(t, "", tp)
+
+		req2 := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		require.Nil(t, clientRequestBuildReq(c, req2))
+		assert.Nil(t, req2.Route(), "no Route should be added once proxy is cleared")
+	})
+
+	t.Run("InvalidHostPortReturnsError", func(t *testing.T) {
+		c, err := NewClient(ua, WithClientHostname("10.0.0.0"))
+		require.Nil(t, err)
+		require.Error(t, c.SetOutboundProxy("not a host port", ""))
+		hp, _ := c.OutboundProxy()
+		assert.Equal(t, "", hp)
+	})
+
+	t.Run("EmptyTransportDoesNotStampParam", func(t *testing.T) {
+		c, err := NewClient(ua,
+			WithClientHostname("10.0.0.0"),
+			WithClientOutboundProxy("proxy.example.com:5080", ""),
+		)
+		require.Nil(t, err)
+
+		req := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		require.Nil(t, clientRequestBuildReq(c, req))
+
+		got := req.Route()
+		require.NotNil(t, got)
+		require.NotNil(t, got.Address.UriParams)
+		assert.True(t, got.Address.UriParams.Has("lr"))
+		_, ok := got.Address.UriParams.Get("transport")
+		assert.False(t, ok, "no ;transport= must be stamped when caller passes empty transport")
+	})
+
+	t.Run("RecipientTransportRespectedWhenProxyTransportEmpty", func(t *testing.T) {
+		c, err := NewClient(ua,
+			WithClientHostname("10.0.0.0"),
+			WithClientOutboundProxy("proxy.example.com:5080", ""),
+		)
+		require.Nil(t, err)
+
+		// Recipient carries the transport hint; outbound proxy does not.
+		recipientTCP := sip.Uri{
+			User:      "bob",
+			Host:      "10.2.2.2",
+			Port:      5060,
+			UriParams: sip.HeaderParams{{K: "transport", V: "tcp"}},
+		}
+		req := sip.NewRequest(sip.INVITE, recipientTCP)
+		require.Nil(t, clientRequestBuildReq(c, req))
+
+		// Destination still follows the proxy.
+		assert.Equal(t, "proxy.example.com:5080", req.Destination())
+		// But the Recipient's transport hint must drive Via and Transport,
+		// since the proxy did not specify its own transport.
+		assert.Equal(t, "TCP", req.Via().Transport, "Via must inherit Recipient transport when proxy transport is empty")
+		assert.Equal(t, "TCP", req.Transport(), "Request.Transport() must reflect the inherited transport")
+	})
+
+	t.Run("RuntimeSwapReflectedOnNextBuild", func(t *testing.T) {
+		c, err := NewClient(ua, WithClientHostname("10.0.0.0"))
+		require.Nil(t, err)
+
+		require.Nil(t, c.SetOutboundProxy("proxy.example.com:5080", "tcp"))
+		req1 := sip.NewRequest(sip.INVITE, recipient)
+		require.Nil(t, clientRequestBuildReq(c, req1))
+		assert.Equal(t, "TCP", req1.Transport())
+		assert.Equal(t, "tcp", req1.Route().Address.UriParams.GetOr("transport", ""))
+
+		require.Nil(t, c.SetOutboundProxy("proxy.example.com:5080", "tls"))
+		req2 := sip.NewRequest(sip.INVITE, recipient)
+		require.Nil(t, clientRequestBuildReq(c, req2))
+		assert.Equal(t, "TLS", req2.Transport(), "next build must observe the swapped transport")
+		assert.Equal(t, "tls", req2.Route().Address.UriParams.GetOr("transport", ""))
+	})
+
+	t.Run("DoesNotOverrideExistingRoute", func(t *testing.T) {
+		c, err := NewClient(ua,
+			WithClientHostname("10.0.0.0"),
+			WithClientOutboundProxy("proxy.example.com:5080", "tcp"),
+		)
+		require.Nil(t, err)
+
+		req := createSimpleRequest(sip.INVITE, sender, recipient, "UDP")
+		// Simulate an in-dialog request that already carries a Route from
+		// Record-Route processing.
+		params := sip.NewParams()
+		params.Add("lr", "")
+		req.PrependHeader(&sip.RouteHeader{
+			Address: sip.Uri{Host: "indialog.example.com", Port: 5060, UriParams: params},
+		})
+
+		require.Nil(t, clientRequestBuildReq(c, req))
+
+		routes := req.GetHeaders("Route")
+		assert.Len(t, routes, 1, "outbound proxy must not stack on top of an existing Route")
+		assert.Equal(t, "indialog.example.com", req.Route().Address.Host)
+	})
+}
+
 /* func TestClientVia(t *testing.T) {
 	ua, err := NewUA()
 	require.Nil(t, err)


### PR DESCRIPTION
## Summary
- Add `ClientRequestAddRoute(uri)` option that prepends a loose-routing
  `Route` header to a request — the standard RFC 3261 §16.12.1 outbound
  proxy mechanism. `Request.Destination()` and `Request.Transport()`
  already honor the top Route URI, so the request is dispatched to the
  proxy while the Request-URI is left untouched.
- Add a client-wide outbound proxy: `WithClientOutboundProxy(hostPort, transport)`,
  `Client.SetOutboundProxy(hostPort, transport)`, and `Client.OutboundProxy()`.
  When set, every out-of-dialog request built by the client gets the loose
  Route auto-prepended. In-dialog requests already carrying a Route from
  Record-Route are not modified.
- The optional `transport` hint (e.g. `"tcp"`, `"tls"`) is stamped as
  `;transport=` on the Route URI **and** surfaced via `req.SetTransport`
  before Via is built, so Via, `req.Transport()`, and the connection chosen
  by the transport layer all agree with the proxy. An empty transport
  preserves prior behavior — Recipient `;transport=` and any explicit
  `req.SetTransport` still drive Via build.

## Test plan
- [x] `go test ./...` (full suite, race-free)
- [x] `TestClientRequestAddRoute` — per-request option: lr handling, URI cloning, Destination override
- [x] `TestClientOutboundProxy/OptionInjectsRouteOnBuild` — auto-injection on default build path
- [x] `TestClientOutboundProxy/TransportStampedOnRouteAndVia` — explicit transport drives Route param + Via.Transport + req.Transport()
- [x] `TestClientOutboundProxy/EmptyTransportDoesNotStampParam` — empty transport leaves Route URI free of `;transport=`
- [x] `TestClientOutboundProxy/RecipientTransportRespectedWhenProxyTransportEmpty` — Recipient `;transport=tcp` still drives Via when proxy transport is empty
- [x] `TestClientOutboundProxy/RuntimeSetterAndClear` + `RuntimeSwapReflectedOnNextBuild` — runtime set/clear and transport swap observed on next build
- [x] `TestClientOutboundProxy/InvalidHostPortReturnsError` — bad host:port surfaces the parse error
- [x] `TestClientOutboundProxy/DoesNotOverrideExistingRoute` — in-dialog request with existing Route is not stacked
