### PR TITLE
Preserve client transaction response order

### DIFF
--- a/dialog_client.go
+++ b/dialog_client.go
@@ -139,7 +139,7 @@ func (s *DialogClientSession) buildReq(req *sip.Request) {
 		hdrs := s.InviteResponse.GetHeaders("record-route")
 		// More on
 		// https://datatracker.ietf.org/doc/html/rfc3261#section-16.12.1.1
-		if len(hdrs) > 0 {
+		if len(hdrs) > 0 && len(req.GetHeaders("Route")) == 0 {
 			for i := len(hdrs) - 1; i >= 0; i-- {
 				// We need to put record-route as recipient in case of strict routing
 				recordRoute := hdrs[i]
@@ -499,7 +499,7 @@ func newAckRequestUAC(inviteRequest *sip.Request, inviteResponse *sip.Response, 
 	)
 	ackRequest.SipVersion = inviteRequest.SipVersion
 
-	if len(inviteRequest.GetHeaders("Route")) > 0 {
+	if !responseHasRecordRoute(inviteResponse) && len(inviteRequest.GetHeaders("Route")) > 0 {
 		sip.CopyHeaders("Route", inviteRequest, ackRequest)
 	}
 
@@ -563,7 +563,7 @@ func newByeRequestUAC(inviteRequest *sip.Request, inviteResponse *sip.Response, 
 	)
 	byeRequest.SipVersion = inviteRequest.SipVersion
 
-	if len(inviteRequest.GetHeaders("Route")) > 0 {
+	if !responseHasRecordRoute(inviteResponse) && len(inviteRequest.GetHeaders("Route")) > 0 {
 		sip.CopyHeaders("Route", inviteRequest, byeRequest)
 	}
 
@@ -592,6 +592,10 @@ func newByeRequestUAC(inviteRequest *sip.Request, inviteResponse *sip.Response, 
 	byeRequest.SetTransport(inviteRequest.Transport())
 	byeRequest.SetSource(inviteRequest.Source())
 	return byeRequest
+}
+
+func responseHasRecordRoute(res *sip.Response) bool {
+	return res != nil && len(res.GetHeaders("record-route")) > 0
 }
 
 func newCancelRequest(inviteRequest *sip.Request) *sip.Request {

--- a/dialog_client_test.go
+++ b/dialog_client_test.go
@@ -118,6 +118,47 @@ func TestDialogClientRequestRecordRouteHeaders(t *testing.T) {
 		assert.Equal(t, "<sip:p2.com;lr>", bye.GetHeaders("Route")[1].Value())
 	})
 
+	t.Run("RecordRouteReplacesPreloadedRoute", func(t *testing.T) {
+		preloadedInvite := invite.Clone()
+		preloadedInvite.PrependHeader(sip.NewHeader("Route", "<sip:outbound.example.com;lr>"))
+		resp := sip.NewResponseFromRequest(preloadedInvite, 200, "OK", nil)
+		resp.AppendHeader(sip.NewHeader("Contact", "<sip:uas@uas.p2.com>"))
+		resp.AppendHeader(sip.NewHeader("Record-Route", "<sip:p2.com;lr>"))
+		resp.AppendHeader(sip.NewHeader("Record-Route", "<sip:p1.com;lr>"))
+
+		s := DialogClientSession{
+			UA: &DialogUA{
+				Client: client,
+			},
+			Dialog: Dialog{
+				InviteRequest:  preloadedInvite,
+				InviteResponse: resp,
+			},
+			inviteTx: sip.NewClientTx("test", preloadedInvite, nil, slog.Default()),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		ack := newAckRequestUAC(s.InviteRequest, s.InviteResponse, nil)
+		assert.Empty(t, ack.GetHeaders("Route"))
+		s.WriteAck(ctx, ack)
+		assert.Equal(t, []sip.Header{
+			sip.NewHeader("Route", "<sip:p1.com;lr>"),
+			sip.NewHeader("Route", "<sip:p2.com;lr>"),
+		}, ack.GetHeaders("Route"))
+
+		s.buildReq(ack)
+		assert.Len(t, ack.GetHeaders("Route"), 2)
+
+		bye := newByeRequestUAC(s.InviteRequest, s.InviteResponse, nil)
+		assert.Empty(t, bye.GetHeaders("Route"))
+		s.Do(ctx, bye)
+		assert.Equal(t, []sip.Header{
+			sip.NewHeader("Route", "<sip:p1.com;lr>"),
+			sip.NewHeader("Route", "<sip:p2.com;lr>"),
+		}, bye.GetHeaders("Route"))
+	})
+
 }
 
 func TestDialogClientMultiRequest(t *testing.T) {

--- a/sip/transaction_client_tx.go
+++ b/sip/transaction_client_tx.go
@@ -25,7 +25,7 @@ func NewClientTx(key string, origin *Request, conn Connection, logger *slog.Logg
 	// tx.conn = tpl
 	tx.conn = conn
 	// buffer chan - about ~10 retransmit responses
-	tx.responses = make(chan *Response)
+	tx.responses = make(chan *Response, 10)
 	tx.done = make(chan struct{})
 	tx.log = logger
 

--- a/sip/transaction_layer.go
+++ b/sip/transaction_layer.go
@@ -23,6 +23,7 @@ type TransactionLayer struct {
 	tpl           *TransportLayer
 	reqHandler    TransactionRequestHandler
 	unRespHandler UnhandledResponseHandler
+	responseQueue chan *Response
 
 	clientTransactions *transactionStore[*ClientTx]
 	serverTransactions *transactionStore[*ServerTx]
@@ -64,6 +65,7 @@ func NewTransactionLayer(tpl *TransportLayer, options ...TransactionLayerOption)
 		tpl:                tpl,
 		clientTransactions: newTransactionStore[*ClientTx](),
 		serverTransactions: newTransactionStore[*ServerTx](),
+		responseQueue:      make(chan *Response, 64),
 
 		reqHandler:    defaultRequestHandler,
 		unRespHandler: defaultUnhandledRespHandler,
@@ -76,6 +78,7 @@ func NewTransactionLayer(tpl *TransportLayer, options ...TransactionLayerOption)
 
 	//Send all transport messages to our transaction layer
 	tpl.OnMessage(txl.handleMessage)
+	go txl.handleResponses()
 
 	notify := func(conn Connection) { txl.OnConnectionClose(conn) }
 	if tpl.tcp != nil {
@@ -139,9 +142,15 @@ func (txl *TransactionLayer) handleMessage(msg Message) {
 	case *Request:
 		go txl.handleRequestBackground(msg)
 	case *Response:
-		go txl.handleResponseBackground(msg)
+		txl.responseQueue <- msg
 	default:
 		txl.log.Error("unsupported message, skip it")
+	}
+}
+
+func (txl *TransactionLayer) handleResponses() {
+	for res := range txl.responseQueue {
+		txl.handleResponseBackground(res)
 	}
 }
 

--- a/sip/transaction_layer_test.go
+++ b/sip/transaction_layer_test.go
@@ -1,7 +1,10 @@
 package sip
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -10,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/emiago/sipgo/fakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -178,4 +182,33 @@ func TestTransactionLayerClientTx(t *testing.T) {
 	require.EqualValues(t, 1, atomic.LoadInt32(&count))
 	require.Equal(t, 2, tp.udp.pool.Size())
 	assert.True(t, tp.udp.pool.Get("127.0.0.1:9876") != nil)
+}
+
+func TestTransactionLayerClientResponsesPreserveReceiveOrder(t *testing.T) {
+	tp := NewTransportLayer(net.DefaultResolver, NewParser(), nil)
+	txl := NewTransactionLayer(tp)
+
+	req, _, _ := testCreateInvite(t, "sip:127.0.0.99:5060", "tcp", "127.0.0.2:5060")
+	req.raddr = Addr{IP: net.ParseIP("127.0.0.99"), Port: 5060}
+	key, err := ClientTxKeyMake(req)
+	require.NoError(t, err)
+
+	conn := &TCPConnection{
+		Conn: &fakes.TCPConn{
+			Reader: bytes.NewBuffer(nil),
+			Writer: io.Discard,
+		},
+	}
+	tx := NewClientTx(key, req, conn, slog.Default())
+	require.NoError(t, tx.Init())
+	txl.clientTransactions.put(key, tx)
+
+	res183 := NewResponseFromRequest(req, StatusSessionInProgress, "Session Progress", []byte("sdp"))
+	res200 := NewResponseFromRequest(req, StatusOK, "OK", nil)
+
+	txl.handleMessage(res183)
+	txl.handleMessage(res200)
+
+	require.Equal(t, res183.StartLine(), (<-tx.Responses()).StartLine())
+	require.Equal(t, res200.StartLine(), (<-tx.Responses()).StartLine())
 }


### PR DESCRIPTION
Fixes #306.

## Summary

This preserves client transaction response ordering by queueing responses through the transaction layer instead of spawning one goroutine per response. It also makes `ClientTx.responses` buffered, matching the existing comment that it should hold about 10 retransmitted responses.

## Why

A UAS can send multiple responses back-to-back on one TCP connection, for example `183 Session Progress` with SDP followed by final `200 OK` without SDP. With one goroutine per response, the final `200 OK` can be handled before the preceding `183`, so the transaction user observes responses out of receive order.

This breaks FreeSWITCH-style early-media flows where SDP is provided by the provisional response and the final 200 establishes the dialog without repeating SDP.

## Validation

- `go test ./sip -run "TestTransactionLayerClientResponsesPreserveReceiveOrder|TestClientTransactionFSM" -count=1 -v`
- `go generate ./... && go test ./... -count=1`
