### PR TITLE
fix(dialog): ACK to 2xx must not copy Route from INVITE

### DIFF
--- a/dialog_client.go
+++ b/dialog_client.go
@@ -499,10 +499,12 @@ func newAckRequestUAC(inviteRequest *sip.Request, inviteResponse *sip.Response, 
 	)
 	ackRequest.SipVersion = inviteRequest.SipVersion
 
-	if len(inviteRequest.GetHeaders("Route")) > 0 {
-		sip.CopyHeaders("Route", inviteRequest, ackRequest)
-	}
-
+	// ACK to 2xx response should not copy over Route header(s) from original INVITE request.
+	// Instead the ACK should include Route header(s) derived from reversing the order of 
+	// Record-Route header(s) in the 2xx response. 
+	// https://datatracker.ietf.org/doc/html/rfc3261#section-12.1.2
+	// https://datatracker.ietf.org/doc/html/rfc3261#section-12.2.1.1
+	
 	if h := inviteRequest.From(); h != nil {
 		ackRequest.AppendHeader(sip.HeaderClone(h))
 	}

--- a/sip/request.go
+++ b/sip/request.go
@@ -246,16 +246,11 @@ func newAckRequestNon2xx(inviteRequest *Request, inviteResponse *Response, body 
 	//  request.
 	CopyHeaders("Via", inviteRequest, ackRequest)
 
+	// If the INVITE request whose response is being acknowledged had Route
+	// header fields, those header fields MUST appear in the ACK to non-2xx response.
 	if len(inviteRequest.GetHeaders("Route")) > 0 {
 		CopyHeaders("Route", inviteRequest, ackRequest)
-	} else {
-		// https://datatracker.ietf.org/doc/html/rfc2543#section-6.29
-		hdrs := inviteResponse.GetHeaders("Record-Route")
-		for i := len(hdrs) - 1; i >= 0; i-- {
-			recordRoute := hdrs[i]
-			ackRequest.AppendHeader(NewHeader("Route", recordRoute.Value()))
-		}
-	}
+	} 
 
 	maxForwardsHeader := MaxForwardsHeader(70)
 	ackRequest.AppendHeader(&maxForwardsHeader)


### PR DESCRIPTION
## Summary

- For a 2xx ACK, RFC 3261 §12.1.2 + §12.2.1.1 require the route-set to be derived from reversing the Record-Route headers in the 200 OK response, not copied from the original INVITE. `buildReq()` already handles this correctly when `WriteAck → WriteRequest` is called, so `newAckRequestUAC` must not also copy the INVITE Route headers (which caused duplicates and wrong `Destination()`).
- For a non-2xx ACK (§17.1.1.3), only the INVITE Route headers should be copied; removed the incorrect `else` branch that was also adding reversed Record-Route headers.
- Fixes `TestDialogClientRequestRecordRouteHeaders` (LooseRouting + StrictRouting subtests).

## Test plan

- [x] `go test ./...` passes green
- [x] `TestDialogClientRequestRecordRouteHeaders/LooseRouting` passes
- [x] `TestDialogClientRequestRecordRouteHeaders/StrictRouting` passes