### PR TITLE
Fix data race on listener close in ListenAndServe

### DIFF
--- a/server.go
+++ b/server.go
@@ -92,25 +92,25 @@ func newBaseServer(ua *UserAgent, options ...ServerOption) (*Server, error) {
 	return s, nil
 }
 
+// closeOnDone closes c once ctx is done.
+//
+// The listener is passed in rather than shared through a variable the caller
+// assigns later, so there is no race between this goroutine's read and that
+// assignment. It also means a context already cancelled by the time the
+// listener exists still closes it, instead of leaking the socket.
+func (srv *Server) closeOnDone(ctx context.Context, c io.Closer) {
+	go func() {
+		<-ctx.Done()
+		if err := c.Close(); err != nil {
+			srv.log.Error("Failed to close listener", "error", err)
+		}
+	}()
+}
+
 // Serve will fire all listeners
 // Network supported: udp, tcp, ws
 func (srv *Server) ListenAndServe(ctx context.Context, network string, addr string) error {
 	network = strings.ToLower(network)
-	var connCloser io.Closer
-
-	// TODO consider different design to avoid this additional go routines
-	go func() {
-		select {
-		case <-ctx.Done():
-			if connCloser == nil {
-				return
-			}
-			if err := connCloser.Close(); err != nil {
-				srv.log.Error("Failed to close listener", "error", err)
-			}
-
-		}
-	}()
 
 	switch network {
 	case "udp", "udp4", "udp6":
@@ -125,7 +125,7 @@ func (srv *Server) ListenAndServe(ctx context.Context, network string, addr stri
 			return fmt.Errorf("listen udp error. err=%w", err)
 		}
 
-		connCloser = udpConn
+		srv.closeOnDone(ctx, udpConn)
 		listenReadyCtx(ctx, network, udpConn.LocalAddr().String())
 		return srv.tp.ServeUDP(udpConn)
 
@@ -140,7 +140,7 @@ func (srv *Server) ListenAndServe(ctx context.Context, network string, addr stri
 			return fmt.Errorf("listen tcp error. err=%w", err)
 		}
 
-		connCloser = conn
+		srv.closeOnDone(ctx, conn)
 		listenReadyCtx(ctx, network, conn.Addr().String())
 
 		return srv.tp.ServeTCP(conn)
@@ -157,7 +157,7 @@ func (srv *Server) ListenAndServe(ctx context.Context, network string, addr stri
 			return fmt.Errorf("listen tcp error. err=%w", err)
 		}
 
-		connCloser = conn
+		srv.closeOnDone(ctx, conn)
 		listenReadyCtx(ctx, network, conn.Addr().String())
 		// and uses listener to buffer
 		return srv.tp.ServeWS(conn)
@@ -170,23 +170,9 @@ func (srv *Server) ListenAndServe(ctx context.Context, network string, addr stri
 func (srv *Server) ListenAndServeTLS(ctx context.Context, network string, addr string, conf *tls.Config) error {
 	network = strings.ToLower(network)
 
-	var connCloser io.Closer
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// TODO consider different design to avoid this additional go routines
-	go func() {
-		select {
-		case <-ctx.Done():
-			if connCloser == nil {
-				return
-			}
-			if err := connCloser.Close(); err != nil {
-				srv.log.Error("Failed to close listener", "error", err)
-			}
-
-		}
-	}()
 	// Support explicitp ipv4 vs ipv6
 	tcpNetwork := "tcp"
 	switch network {
@@ -216,7 +202,7 @@ func (srv *Server) ListenAndServeTLS(ctx context.Context, network string, addr s
 			return fmt.Errorf("listen tls error. err=%w", err)
 		}
 
-		connCloser = listener
+		srv.closeOnDone(ctx, listener)
 		listenReadyCtx(ctx, network, listener.Addr().String())
 
 		if network == "wss" {

--- a/server_listener_race_test.go
+++ b/server_listener_race_test.go
@@ -1,0 +1,128 @@
+package sipgo
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// listenReady returns a context that reports the address a listener binds to,
+// using the library's own ListenReady hook. Binding to port 0 and learning the
+// result this way avoids racing the server for a fixed port.
+func listenReady(t *testing.T, parent context.Context) (context.Context, <-chan string) {
+	t.Helper()
+
+	ch := make(chan string, 1)
+	var once sync.Once
+	fn := ListenReadyFuncCtxValue(func(network, addr string) {
+		once.Do(func() { ch <- addr })
+	})
+	return context.WithValue(parent, ListenReadyCtxKey, fn), ch
+}
+
+// waitPortFree reports whether addr can be bound again, retrying briefly since
+// the close is asynchronous.
+func waitPortFree(addr string, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for {
+		c, err := net.ListenPacket("udp", addr)
+		if err == nil {
+			c.Close()
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+
+	ua, err := NewUA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ua.Close() })
+
+	srv, err := NewServer(ua)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+// TestListenAndServeClosesListenerOnCancel checks that cancelling the context
+// actually closes the listener.
+//
+// Previously the closer goroutine started before the listener existed and read
+// a variable the caller assigned afterwards. That was a data race, and when the
+// goroutine observed the pre-assignment nil it returned early and the socket
+// was never closed. Run with -race.
+func TestListenAndServeClosesListenerOnCancel(t *testing.T) {
+	srv := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, ready := listenReady(t, ctx)
+
+	served := make(chan error, 1)
+	go func() { served <- srv.ListenAndServe(ctx, "udp", "127.0.0.1:0") }()
+
+	var addr string
+	select {
+	case addr = <-ready:
+	case err := <-served:
+		cancel()
+		t.Fatalf("ListenAndServe returned before listening: %v", err)
+	case <-time.After(3 * time.Second):
+		cancel()
+		t.Fatal("listener never became ready")
+	}
+
+	cancel()
+
+	select {
+	case <-served:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ListenAndServe did not return after cancel")
+	}
+
+	if !waitPortFree(addr, 2*time.Second) {
+		t.Fatalf("listener at %s was not closed on cancel", addr)
+	}
+}
+
+// TestListenAndServeCancelledBeforeBind covers the case the old code leaked
+// most reliably: a context already done by the time the listener is created.
+// The closer goroutine saw a nil closer, returned, and nothing ever closed the
+// socket.
+func TestListenAndServeCancelledBeforeBind(t *testing.T) {
+	srv := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, ready := listenReady(t, ctx)
+	cancel() // already done before ListenAndServe runs
+
+	served := make(chan error, 1)
+	go func() { served <- srv.ListenAndServe(ctx, "udp", "127.0.0.1:0") }()
+
+	var addr string
+	select {
+	case addr = <-ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("listener never reported ready")
+	}
+
+	select {
+	case <-served:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ListenAndServe did not return")
+	}
+
+	if !waitPortFree(addr, 2*time.Second) {
+		t.Fatalf("listener at %s leaked when context was cancelled before bind", addr)
+	}
+}


### PR DESCRIPTION
Fixes #315.

## Problem

`ListenAndServe` and `ListenAndServeTLS` declare a `connCloser` variable and
spawn a goroutine that reads it on `ctx.Done()`, then assign it only after the
listener has been created. The read and the write are unsynchronised.

```go
var connCloser io.Closer

// TODO consider different design to avoid this additional go routines
go func() {
	select {
	case <-ctx.Done():
		if connCloser == nil {   // <-- read
			return
		}
		if err := connCloser.Close(); err != nil {
			...
		}
	}
}()

// ...
connCloser = udpConn             // <-- write
```

Beyond being a data race, this leaks sockets. When the goroutine observes the
pre-assignment `nil` it returns early and **nothing ever closes the listener**.
That is hit most reliably when the context is already cancelled by the time the
listener is created, and it shows up in test suites that start a server per
case, where it eventually exhausts ports.

Because the read only happens on `ctx.Done()`, it stays invisible in
long-running servers and surfaces in tests and in code that restarts listeners.

## Fix

Pass the listener to a small `closeOnDone` helper rather than sharing it through
a variable assigned later. The value is captured, so there is nothing to race
on, and a context that is already done still closes the listener instead of
leaking it.

```go
func (srv *Server) closeOnDone(ctx context.Context, c io.Closer) {
	go func() {
		<-ctx.Done()
		if err := c.Close(); err != nil {
			srv.log.Error("Failed to close listener", "error", err)
		}
	}()
}
```

This also resolves the existing `// TODO consider different design to avoid this
additional go routines` and drops the now-unnecessary `nil` check.

Applied to every transport branch: UDP, TCP, WS, TLS and WSS.

## Tests

Two regression tests in `server_listener_race_test.go`:

- `TestListenAndServeClosesListenerOnCancel` — cancelling the context must close
  the listener.
- `TestListenAndServeCancelledBeforeBind` — the case the old code leaked most
  reliably.

Both use the existing `ListenReadyCtxKey` / `ListenReadyFuncCtxValue` hook with
port `0`, so they neither hard-code a port nor race the server to bind one.

On current `main` under `-race`:

```
WARNING: DATA RACE
--- FAIL: TestListenAndServeCancelledBeforeBind (3.00s)
```

With this change, passing with `-count=5`:

```
ok  	github.com/emiago/sipgo	1.470s
```

## Notes

Two tests fail on `main` both before and after this change, unrelated to it:
`TestClientWriteRequestRejectsCRLFAfterBuild` and
`TestClientTransactionRequestRejectsCRLFAfterBuild` in the root package, plus
`TestServerTransactionRespondRejectsCRLF` in `sip/`. I have left those alone.

Behaviour is otherwise unchanged: the non-TLS path still closes only on parent
context cancellation, and the TLS path keeps its `defer cancel()` so the
listener is closed when the function returns.
