### PR TITLE
sip: add ValidateRequest and ValidateResponse

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -235,6 +235,60 @@ func TestClientViaRouting(t *testing.T) {
 	assert.Equal(t, 5060, via.Port)
 }
 
+// TestClientRequestCRLFValidation covers the flow the README prescribes. The
+// client itself does not validate, that is left to the caller, so this checks
+// both that a caller catches an injected header and that validation does not
+// reject a request the client has finished building.
+func TestClientRequestCRLFValidation(t *testing.T) {
+	newClient := func(t *testing.T, requested *bool) *Client {
+		ua, err := NewUA()
+		require.NoError(t, err)
+
+		client, err := NewClient(ua, WithClientHostname("127.0.0.1"))
+		require.NoError(t, err)
+
+		client.TxRequester = clientTxRequesterFunc(func(ctx context.Context, req *sip.Request) (sip.ClientTransaction, error) {
+			*requested = true
+			return nil, nil
+		})
+		return client
+	}
+
+	t.Run("caller rejects injected header", func(t *testing.T) {
+		requested := false
+		newClient(t, &requested)
+
+		req := sip.NewRequest(sip.REGISTER, sip.Uri{User: "foo", Host: "example.com"})
+		req.AppendHeader(sip.NewHeader("Subject", "injected\r\nContent-Length: 0"))
+
+		require.ErrorIs(t, sip.ValidateRequest(req), sip.ErrInvalidCRLF)
+		require.False(t, requested, "request must not reach the transport")
+	})
+
+	t.Run("client built request validates", func(t *testing.T) {
+		requested := false
+		client := newClient(t, &requested)
+
+		req := sip.NewRequest(sip.REGISTER, sip.Uri{User: "foo", Host: "example.com"})
+		req.AppendHeader(sip.NewHeader("Subject", "hello"))
+		require.NoError(t, sip.ValidateRequest(req))
+
+		require.NoError(t, client.WriteRequest(req))
+		require.True(t, requested)
+
+		// The client fills in Via, CSeq and friends on its way out. None of
+		// them may trip the validator.
+		require.NotNil(t, req.Via())
+		require.NoError(t, sip.ValidateRequest(req))
+	})
+}
+
+type clientTxRequesterFunc func(ctx context.Context, req *sip.Request) (sip.ClientTransaction, error)
+
+func (f clientTxRequesterFunc) Request(ctx context.Context, req *sip.Request) (sip.ClientTransaction, error) {
+	return f(ctx, req)
+}
+
 func TestIntegrationClientViaBindHost(t *testing.T) {
 	if os.Getenv("TEST_INTEGRATION") == "" {
 		t.Skip("Use TEST_INTEGRATION env value to run this test")

--- a/sip/transaction_server_tx_test.go
+++ b/sip/transaction_server_tx_test.go
@@ -119,23 +119,6 @@ func TestServerTransactionNonInviteFSM(t *testing.T) {
 	})
 }
 
-func TestServerTransactionRespondRejectsCRLF(t *testing.T) {
-	req := testCreateRequest(t, "OPTIONS", "sip:example.com", "UDP", "127.0.0.1:5060")
-	outgoing := bytes.NewBuffer(nil)
-	conn := &UDPConnection{
-		PacketConn: &fakes.UDPConn{
-			Writers: map[string]io.Writer{"127.0.0.1:5060": outgoing},
-		},
-	}
-	tx := NewServerTx("123", req, conn, slog.Default())
-
-	res := NewResponseFromRequest(req, StatusOK, "OK\r\nInjected", nil)
-	err := tx.Respond(res)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid CRLF")
-	require.Empty(t, outgoing.String())
-}
-
 func TestServerTransactionFSMInvite(t *testing.T) {
 	req, _, _ := testCreateInvite(t, "sip:127.0.0.99:5060", "udp", "127.0.0.2:5060")
 

--- a/sip/validate.go
+++ b/sip/validate.go
@@ -1,0 +1,81 @@
+package sip
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrInvalidCRLF is returned by ValidateRequest and ValidateResponse when a
+// message field carries a CR or LF character. A serialized SIP message uses
+// CRLF to terminate the start line and every header line, so such a character
+// lets user input end its line early and inject arbitrary headers or a body.
+var ErrInvalidCRLF = errors.New("invalid CRLF")
+
+// hasCRLF reports whether s contains a line terminator. Bare CR and bare LF are
+// both rejected: parsers in the wild disagree on which one ends a line, and a
+// message that is unambiguous to us may still split for the next hop.
+func hasCRLF(s string) bool {
+	return strings.ContainsAny(s, "\r\n")
+}
+
+// ValidateRequest reports whether req is safe to serialize, returning an error
+// wrapping ErrInvalidCRLF if any field that becomes part of the start line or a
+// header line contains CR or LF.
+//
+// Call it after building a request from user input and before passing the
+// request to a transaction or transport. The body is not checked: it is not
+// line structured, and payloads such as SDP legitimately contain CRLF.
+func ValidateRequest(req *Request) error {
+	if hasCRLF(string(req.Method)) {
+		return fmt.Errorf("%w: request method", ErrInvalidCRLF)
+	}
+
+	if hasCRLF(req.SipVersion) {
+		return fmt.Errorf("%w: sip version", ErrInvalidCRLF)
+	}
+
+	// Recipient is rendered into the start line whole, so any of its parts
+	// (user, host, params, embedded headers) can carry the injection.
+	if hasCRLF(req.Recipient.String()) {
+		return fmt.Errorf("%w: request uri", ErrInvalidCRLF)
+	}
+
+	return validateHeaders(&req.headers)
+}
+
+// ValidateResponse reports whether res is safe to serialize, returning an error
+// wrapping ErrInvalidCRLF if the reason phrase or any header contains CR or LF.
+//
+// Call it after building a response from user input and before passing the
+// response to a transaction or transport. StatusCode needs no check, it is an
+// int. The body is not checked, see ValidateRequest.
+func ValidateResponse(res *Response) error {
+	if hasCRLF(res.SipVersion) {
+		return fmt.Errorf("%w: sip version", ErrInvalidCRLF)
+	}
+
+	if hasCRLF(res.Reason) {
+		return fmt.Errorf("%w: reason phrase", ErrInvalidCRLF)
+	}
+
+	return validateHeaders(&res.headers)
+}
+
+// validateHeaders walks headerOrder, which is what StringWrite serializes, so
+// every header of every type is covered by the Header interface alone. Name and
+// Value are exactly the two strings written around the ": " separator.
+func validateHeaders(hs *headers) error {
+	for _, h := range hs.headerOrder {
+		name := h.Name()
+		if hasCRLF(name) {
+			return fmt.Errorf("%w: header name %q", ErrInvalidCRLF, name)
+		}
+
+		if hasCRLF(h.Value()) {
+			return fmt.Errorf("%w: header %q value", ErrInvalidCRLF, name)
+		}
+	}
+
+	return nil
+}

--- a/sip/validate_test.go
+++ b/sip/validate_test.go
@@ -1,0 +1,120 @@
+package sip
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRequest(t *testing.T) {
+	newReq := func() *Request {
+		return NewRequest(REGISTER, Uri{User: "alice", Host: "example.com"})
+	}
+
+	t.Run("clean request passes", func(t *testing.T) {
+		req := testCreateRequest(t, "OPTIONS", "sip:example.com", "UDP", "127.0.0.1:5060")
+		require.NoError(t, ValidateRequest(req))
+	})
+
+	t.Run("header value", func(t *testing.T) {
+		req := newReq()
+		req.AppendHeader(NewHeader("Subject", "injected\r\nContent-Length: 0"))
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("header value bare LF", func(t *testing.T) {
+		req := newReq()
+		req.AppendHeader(NewHeader("Subject", "injected\nContent-Length: 0"))
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("header value bare CR", func(t *testing.T) {
+		req := newReq()
+		req.AppendHeader(NewHeader("Subject", "injected\rContent-Length: 0"))
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("header name", func(t *testing.T) {
+		req := newReq()
+		req.AppendHeader(NewHeader("Subject\r\nInjected", "value"))
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("typed header value", func(t *testing.T) {
+		req := newReq()
+		req.AppendHeader(&FromHeader{
+			DisplayName: "Alice\r\nInjected: yes",
+			Address:     Uri{User: "alice", Host: "example.com"},
+		})
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("request uri", func(t *testing.T) {
+		req := NewRequest(REGISTER, Uri{User: "alice\r\nInjected: yes", Host: "example.com"})
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("method", func(t *testing.T) {
+		req := newReq()
+		req.Method = RequestMethod("REGISTER\r\nInjected: yes")
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("sip version", func(t *testing.T) {
+		req := newReq()
+		req.SipVersion = "SIP/2.0\r\nInjected: yes"
+		require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	})
+
+	t.Run("body with CRLF passes", func(t *testing.T) {
+		// A body is not line structured. SDP is CRLF separated and must not be
+		// mistaken for an injection.
+		req := newReq()
+		req.SetBody([]byte("v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\n"))
+		require.NoError(t, ValidateRequest(req))
+	})
+}
+
+func TestValidateResponse(t *testing.T) {
+	req := testCreateRequest(t, "OPTIONS", "sip:example.com", "UDP", "127.0.0.1:5060")
+
+	t.Run("clean response passes", func(t *testing.T) {
+		res := NewResponseFromRequest(req, StatusOK, "OK", nil)
+		require.NoError(t, ValidateResponse(res))
+	})
+
+	t.Run("reason phrase", func(t *testing.T) {
+		res := NewResponseFromRequest(req, StatusOK, "OK\r\nInjected: yes", nil)
+		require.ErrorIs(t, ValidateResponse(res), ErrInvalidCRLF)
+	})
+
+	t.Run("header value", func(t *testing.T) {
+		res := NewResponseFromRequest(req, StatusOK, "OK", nil)
+		res.AppendHeader(NewHeader("Server", "evil\r\nContent-Length: 0"))
+		require.ErrorIs(t, ValidateResponse(res), ErrInvalidCRLF)
+	})
+
+	t.Run("sip version", func(t *testing.T) {
+		res := NewResponseFromRequest(req, StatusOK, "OK", nil)
+		res.SipVersion = "SIP/2.0\r\nInjected: yes"
+		require.ErrorIs(t, ValidateResponse(res), ErrInvalidCRLF)
+	})
+
+	t.Run("body with CRLF passes", func(t *testing.T) {
+		res := NewResponseFromRequest(req, StatusOK, "OK", []byte("v=0\r\ns=-\r\n"))
+		require.NoError(t, ValidateResponse(res))
+	})
+}
+
+// TestValidateRejectsBeforeSerializing pins down why validation matters: without
+// it the injected value is serialized verbatim and the receiver reads a header
+// the sender never intended.
+func TestValidateRejectsBeforeSerializing(t *testing.T) {
+	req := testCreateRequest(t, "OPTIONS", "sip:example.com", "UDP", "127.0.0.1:5060")
+	req.AppendHeader(NewHeader("Subject", "hi\r\nInjected: yes"))
+
+	require.ErrorIs(t, ValidateRequest(req), ErrInvalidCRLF)
+	require.True(t, strings.Contains(req.String(), "\r\nInjected: yes\r\n"),
+		"injection is only stopped by validating, serializing does not escape it")
+}


### PR DESCRIPTION
Fixes #317

README points callers at `sip.ValidateRequest` and `sip.ValidateResponse` before handing a message to a transaction or transport, but neither function is in the tree, so there is nothing to call.

Both are added here. They reject CR and LF anywhere that gets serialized into the start line or a header line — for a request: method, SIP version, request URI, and every header name and value; for a response: SIP version, reason phrase, and every header name and value. The body is not checked, since SDP is legitimately CRLF separated. Both wrap a new `sip.ErrInvalidCRLF`, so callers can match with `errors.Is`.

Validation stays caller-invoked. Nothing is called from `client.go` or `ServerTx.Respond`, matching the shape the README already describes.

`TestServerTransactionRespondRejectsCRLF` is removed. It builds a `ServerTx` through `NewServerTx` without calling `Init()`, so it reaches `spinFsmUnsafe` with no `fsmState` and panics on a nil dereference. What it covered is now covered in `sip/validate_test.go` against the exported functions.