### PR TITLE
transport: honor DialURI in WSS CreateConnection

### DIFF
--- a/sip/transport_wss.go
+++ b/sip/transport_wss.go
@@ -16,6 +16,10 @@ type TransportWSS struct {
 }
 
 func (t *TransportWSS) init(par *Parser, dialTLSConf *tls.Config) {
+	// Set before TransportWS.init, which otherwise defaults this to the ws:// scheme.
+	if t.DialURI == nil {
+		t.DialURI = func(addr string) string { return "wss://" + addr }
+	}
 	t.TransportWS.init(par)
 	t.TransportWS.transport = "WSS"
 	t.dialer.TLSConfig = dialTLSConf
@@ -91,7 +95,7 @@ func (t *TransportWSS) CreateConnection(ctx context.Context, laddr Addr, raddr A
 		log.Debug("Setuping TLS connection", "hostname", hostname)
 		tlsConn := t.dialer.TLSClient(conn, hostname)
 
-		u, err := url.ParseRequestURI("wss://" + addr)
+		u, err := url.ParseRequestURI(t.DialURI(addr))
 		if err != nil {
 			return nil, fmt.Errorf("parse request wss uri failed: %w", err)
 		}

--- a/sip/transport_wss_test.go
+++ b/sip/transport_wss_test.go
@@ -1,0 +1,30 @@
+package sip
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestTransportWSSDialURI(t *testing.T) {
+	t.Run("defaults to wss scheme", func(t *testing.T) {
+		tran := &TransportWSS{TransportWS: &TransportWS{}}
+		tran.init(NewParser(), &tls.Config{})
+
+		got := tran.DialURI("localhost:443")
+		if got != "wss://localhost:443" {
+			t.Fatalf("expected wss://localhost:443, got %q", got)
+		}
+	})
+
+	t.Run("caller DialURI is kept", func(t *testing.T) {
+		tran := &TransportWSS{TransportWS: &TransportWS{
+			DialURI: func(host string) string { return "wss://" + host + "/ws" },
+		}}
+		tran.init(NewParser(), &tls.Config{})
+
+		got := tran.DialURI("localhost:443")
+		if got != "wss://localhost:443/ws" {
+			t.Fatalf("expected wss://localhost:443/ws, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #319

`NewTransportLayer` sets a `DialURI` default for WSS, but `TransportWSS` declares its own `CreateConnection`, which shadows the promoted `TransportWS` method and builds the handshake URL from a hardcoded `"wss://" + addr`. The field is never read on that path, so a caller setting a handshake path has no effect over WSS and the dialer always requests `/`.

`CreateConnection` now reads `t.DialURI(addr)`. `TransportWSS.init` sets the `wss://` default before calling `TransportWS.init`, which would otherwise default it to `ws://` and dial the wrong scheme over TLS — both halves are needed.

6 lines of source, plus a test covering the default and that a caller-supplied `DialURI` is kept.