### PR TITLE
transaction: preserve the error chain in wrapTransportError

### DIFF
--- a/sip/transaction.go
+++ b/sip/transaction.go
@@ -79,8 +79,10 @@ var (
 	ErrTransactionTerminated = errors.New("transaction terminated")
 )
 
+// wrapTransportError wraps the cause with %w so it stays reachable through
+// errors.Is and errors.As. Matching on ErrTransactionTransport is unaffected.
 func wrapTransportError(err error) error {
-	return fmt.Errorf("%s. %w", err.Error(), ErrTransactionTransport)
+	return fmt.Errorf("%w. %w", err, ErrTransactionTransport)
 }
 
 func wrapTimeoutError(err error) error {

--- a/sip/transaction_client_tx_test.go
+++ b/sip/transaction_client_tx_test.go
@@ -2,6 +2,7 @@ package sip
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log/slog"
 	"net"
@@ -128,4 +129,14 @@ func TestClientTransactionFSM(t *testing.T) {
 		// State should not change from answered
 		require.NoError(t, compareFunctions(tx.currentFsmState(), tx.inviteStateAccepted))
 	})
+}
+
+func TestWrapTransportErrorPreservesCause(t *testing.T) {
+	cause := errors.New("write: connection refused")
+	err := wrapTransportError(cause)
+
+	// Existing callers matching the transport error keep working
+	require.ErrorIs(t, err, ErrTransactionTransport)
+	// and the cause is now reachable instead of being flattened into the message
+	require.ErrorIs(t, err, cause)
 }


### PR DESCRIPTION
Fixes #321

`wrapTransportError` rendered the cause with `%s`, so only `ErrTransactionTransport` stayed matchable and the underlying write or dial failure was unreachable through `errors.Is` and `errors.As`.

The cause is wrapped with `%w` instead. Matching on `ErrTransactionTransport` is unchanged — the added test asserts both.