### PR TITLE
parser: bound the stream parser on an incomplete message

### DIFF
--- a/sip/parser_stream.go
+++ b/sip/parser_stream.go
@@ -122,6 +122,12 @@ func (p *ParserStream) Write(data []byte) (int, error) {
 
 // ParseNext parses the next SIP message from an internal buffer.
 // It may return io.ErrUnexpectedEOF, indicating that more data needs to be written with Write.
+//
+// ErrMessageTooLarge is returned in two shapes. If the oversized message was
+// parsed in full, it is fully consumed from the buffer and the stream can be
+// recovered by simply calling ParseNext again. If it is still incomplete, the
+// stream cannot be recovered: there is no message boundary to skip to, so the
+// buffer is drained and the caller should close the connection.
 func (p *ParserStream) ParseNext() (Message, int, error) {
 	if p.buf == nil {
 		return nil, 0, io.ErrUnexpectedEOF
@@ -129,8 +135,24 @@ func (p *ParserStream) ParseNext() (Message, int, error) {
 	err := p.parseSingle()
 	reset := err == nil
 	msg, n := p.msg, p.totalRead
-	if err == nil && p.totalRead > p.p.MaxMessageLength {
-		err = ErrMessageTooLarge
+	if err == nil {
+		if p.totalRead > p.p.MaxMessageLength {
+			err = ErrMessageTooLarge
+		}
+	} else if errors.Is(err, io.ErrUnexpectedEOF) {
+		// The message is incomplete, so everything still buffered belongs to it:
+		// totalRead counts what has already been drained into the message, and
+		// buf holds a line that has not terminated yet. Neither pool is bounded
+		// on its own. Headers streamed in complete lines drain as they arrive and
+		// keep buf near empty while the message grows without limit; a line that
+		// never terminates does the reverse. Only their sum bounds the peer.
+		if p.totalRead+p.buf.Len() > p.p.MaxMessageLength {
+			// Unrecoverable, so do not keep the bytes we just refused to assemble.
+			// Reporting the error while still holding them would leave the peer's
+			// memory in place for any caller that logs and reads on.
+			p.Discard(p.buf.Len())
+			return nil, n, ErrMessageTooLarge
+		}
 	}
 	if reset {
 		p.reset()

--- a/sip/parser_stream_test.go
+++ b/sip/parser_stream_test.go
@@ -629,3 +629,70 @@ func BenchmarkParserStream(b *testing.B) {
 	})
 
 }
+
+// A peer that streams complete header lines and never terminates the header
+// block keeps the internal buffer near empty, because every complete line is
+// drained into the message as soon as it arrives. Only the assembled message
+// grows, so bounding the buffer alone can never stop this.
+func TestParserStreamMessageSizeLimitStreamedHeaders(t *testing.T) {
+	p := NewParser()
+	parser := p.NewSIPStream()
+	defer parser.Close()
+
+	header := "X-Data: " + strings.Repeat("a", 200) + "\r\n"
+
+	var (
+		fed int
+		err error
+	)
+	for range 2000 {
+		data := []byte(header)
+		if fed == 0 {
+			data = []byte("INVITE sip:192.168.1.254:5060 SIP/2.0\r\n" + header)
+		}
+		fed += len(data)
+
+		err = parser.ParseSIPStream(data, func(msg Message) {
+			t.Error("no message may be delivered from an oversized stream")
+		})
+		if err != ErrParseSipPartial {
+			break
+		}
+	}
+
+	require.Equal(t, ErrMessageTooLarge, err)
+	require.Less(t, fed, 2*p.MaxMessageLength, "peer must be stopped near the limit")
+	require.Zero(t, parser.totalRead, "refused message must not be retained")
+	require.Zero(t, parser.Buffer().Len(), "refused bytes must not be retained")
+}
+
+// The mirror of the streamed-header case: a header line that never terminates is
+// never drained into the message, so it grows the buffer instead and leaves
+// totalRead at the start line. Both pools need the same bound.
+func TestParserStreamMessageSizeLimitUnterminatedLine(t *testing.T) {
+	p := NewParser()
+	parser := p.NewSIPStream()
+	defer parser.Close()
+
+	err := parser.ParseSIPStream([]byte("INVITE sip:192.168.1.254:5060 SIP/2.0\r\nX-Data: "), func(msg Message) {
+		t.Error("no message may be delivered from an oversized stream")
+	})
+	require.Equal(t, ErrParseSipPartial, err)
+
+	chunk := []byte(strings.Repeat("a", 4096))
+	fed := 0
+	for range 2000 {
+		fed += len(chunk)
+
+		err = parser.ParseSIPStream(chunk, func(msg Message) {
+			t.Error("no message may be delivered from an oversized stream")
+		})
+		if err != ErrParseSipPartial {
+			break
+		}
+	}
+
+	require.Equal(t, ErrMessageTooLarge, err)
+	require.Less(t, fed, 2*p.MaxMessageLength, "peer must be stopped near the limit")
+	require.Zero(t, parser.Buffer().Len(), "refused bytes must not be retained")
+}

--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -219,11 +219,16 @@ func (t *TransportTCP) readConnection(conn *TCPConnection, laddr string, raddr s
 		// TODO fallback to parseFull if message size limit is set
 
 		// t.log.Debug().Str("raddr", raddr).Str("data", string(data)).Msg("new message")
-		t.parseStream(par, data, raddr, handler)
+		if err := t.parseStream(par, data, raddr, handler); errors.Is(err, ErrMessageTooLarge) {
+			// The parser could not frame a message within the size limit, so there
+			// is no boundary left to resync on. Reading on would only let the peer
+			// repeat it, so close the connection instead.
+			return
+		}
 	}
 }
 
-func (t *TransportTCP) parseStream(par *ParserStream, data []byte, src string, handler MessageHandler) {
+func (t *TransportTCP) parseStream(par *ParserStream, data []byte, src string, handler MessageHandler) error {
 	err := par.ParseSIPStream(data, func(msg Message) {
 		msg.SetTransport(t.Network())
 		msg.SetSource(src)
@@ -232,11 +237,12 @@ func (t *TransportTCP) parseStream(par *ParserStream, data []byte, src string, h
 
 	if err != nil {
 		if err == ErrParseSipPartial {
-			return
+			return nil
 		}
 		t.log.Error("failed to parse", "error", err, "data", string(data))
-		return
+		return err
 	}
+	return nil
 }
 
 type TCPConnection struct {


### PR DESCRIPTION
Fixes #323

The size limit was only checked once a message parsed in full, so a peer that never finishes one was never stopped.
