### PR TITLE
transport: answer WS pings and read the control payload out of the stream

### DIFF
--- a/sip/transport_ws.go
+++ b/sip/transport_ws.go
@@ -318,6 +318,27 @@ type WSConnection struct {
 	clientSide bool
 	mu         sync.RWMutex
 	refcount   int
+
+	// writeMu serializes frame writes on Conn. ws frame writing is not safe for
+	// concurrent use on a single net.Conn, and a Pong written from the read
+	// goroutine may race WriteMsg. Without this two frames can interleave on the
+	// wire and neither one decodes.
+	writeMu sync.Mutex
+}
+
+func (c *WSConnection) state() ws.State {
+	if c.clientSide {
+		return ws.StateClientSide
+	}
+	return ws.StateServerSide
+}
+
+// writeFrame writes a single frame. Every frame written on this connection must
+// go through here to keep writes serialized.
+func (c *WSConnection) writeFrame(f ws.Frame) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return ws.WriteFrame(c.Conn, f)
 }
 
 func (c *WSConnection) Ref(i int) int {
@@ -356,11 +377,24 @@ func (c *WSConnection) TryClose() (int, error) {
 	return ref, c.Conn.Close()
 }
 
+// handleControlFrame answers a Ping with a Pong and discards a Pong, reading the
+// control payload out of reader either way. The write lock is held across the
+// whole handler because it may write a header and payload separately, and those
+// must not be split by a concurrent Write.
+func (c *WSConnection) handleControlFrame(header ws.Header, reader io.Reader, state ws.State) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return wsutil.ControlHandler{
+		Src: reader,
+		Dst: c.Conn,
+		// reader already unmasks the payload it yields.
+		DisableSrcCiphering: true,
+		State:               state,
+	}.Handle(header)
+}
+
 func (c *WSConnection) Read(b []byte) (n int, err error) {
-	state := ws.StateServerSide
-	if c.clientSide {
-		state = ws.StateClientSide
-	}
+	state := c.state()
 	reader := wsutil.NewReader(c.Conn, state)
 	reader.MaxFrameSize = int64(ParseMaxMessageLength)
 	for {
@@ -380,6 +414,12 @@ func (c *WSConnection) Read(b []byte) (n int, err error) {
 		if header.OpCode.IsControl() {
 			if header.OpCode == ws.OpClose {
 				return n, net.ErrClosed
+			}
+			// Ping must be answered with a Pong carrying the same payload, and
+			// any control payload must be read out of the stream, otherwise the
+			// next header read starts mid payload. See RFC 6455 section 5.5.
+			if err := c.handleControlFrame(header, reader, state); err != nil {
+				return n, err
 			}
 			continue
 		}
@@ -405,12 +445,6 @@ func (c *WSConnection) Read(b []byte) (n int, err error) {
 		if err != nil {
 			return n, err
 		}
-
-		// if header.OpCode == ws.OpPing {
-		// 	f := ws.NewPongFrame(data)
-		// 	ws.WriteFrame(c.Conn, f)
-		// 	continue
-		// }
 
 		if header.Masked {
 			ws.Cipher(data, header.Mask, 0)
@@ -440,7 +474,7 @@ func (c *WSConnection) Write(b []byte) (n int, err error) {
 	if c.clientSide {
 		fs = ws.MaskFrameInPlace(fs)
 	}
-	err = ws.WriteFrame(c.Conn, fs)
+	err = c.writeFrame(fs)
 
 	return len(b), err
 }

--- a/sip/transport_ws_test.go
+++ b/sip/transport_ws_test.go
@@ -1,0 +1,171 @@
+package sip
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readFrameAsync reads one frame from conn without blocking the caller.
+func readFrameAsync(t *testing.T, conn net.Conn) <-chan ws.Frame {
+	t.Helper()
+	ch := make(chan ws.Frame, 1)
+	go func() {
+		f, err := ws.ReadFrame(conn)
+		if err != nil {
+			return
+		}
+		ch <- f
+	}()
+	return ch
+}
+
+func mustReadFrame(t *testing.T, ch <-chan ws.Frame) ws.Frame {
+	t.Helper()
+	select {
+	case f := <-ch:
+		return f
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for frame")
+		return ws.Frame{}
+	}
+}
+
+// TestWSConnectionPingIsAnsweredWithPong checks RFC 6455 section 5.5.2: a Pong
+// must carry the same payload as the Ping it answers. The text frame sent after
+// the ping must still decode, which only holds if the ping payload was read out
+// of the stream instead of being left for the next header read.
+func TestWSConnectionPingIsAnsweredWithPong(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+	defer c.Close()
+
+	readCh := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 1024)
+		n, err := c.Read(buf)
+		if err != nil {
+			return
+		}
+		readCh <- string(buf[:n])
+	}()
+
+	// Client side must mask its frames.
+	go func() {
+		ping := ws.MaskFrameInPlace(ws.NewPingFrame([]byte("keepalive")))
+		if err := ws.WriteFrame(clientConn, ping); err != nil {
+			return
+		}
+		text := ws.MaskFrameInPlace(ws.NewTextFrame([]byte("OPTIONS sip:x SIP/2.0\r\n\r\n")))
+		_ = ws.WriteFrame(clientConn, text)
+	}()
+
+	pong := mustReadFrame(t, readFrameAsync(t, clientConn))
+	assert.Equal(t, ws.OpPong, pong.Header.OpCode)
+	assert.Equal(t, []byte("keepalive"), pong.Payload, "pong must echo the ping payload")
+
+	select {
+	case got := <-readCh:
+		assert.Equal(t, "OPTIONS sip:x SIP/2.0\r\n\r\n", got, "text frame after ping must still decode")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: stream desynced after ping with payload")
+	}
+}
+
+// TestWSConnectionEmptyPingIsAnsweredWithPong covers the common empty ping,
+// which the control handler answers on a header-only fast path.
+func TestWSConnectionEmptyPingIsAnsweredWithPong(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+	defer c.Close()
+
+	go func() {
+		buf := make([]byte, 1024)
+		_, _ = c.Read(buf)
+	}()
+
+	go func() {
+		_ = ws.WriteFrame(clientConn, ws.MaskFrameInPlace(ws.NewPingFrame(nil)))
+	}()
+
+	pong := mustReadFrame(t, readFrameAsync(t, clientConn))
+	assert.Equal(t, ws.OpPong, pong.Header.OpCode)
+	assert.Empty(t, pong.Payload)
+}
+
+// TestWSConnectionConcurrentWrites exercises concurrent SIP writes on one
+// connection. Frames must not interleave on the wire, so every frame the peer
+// reads has to decode. Run with -race to also catch unsynchronized access to
+// the underlying conn.
+func TestWSConnectionConcurrentWrites(t *testing.T) {
+	const writers, perWriter = 8, 50
+
+	serverConn, clientConn := net.Pipe()
+
+	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+
+	// Deadlines bound both ends. If writes interleave the peer sees a corrupt
+	// frame and stops reading, which would otherwise block the writers on the
+	// unbuffered pipe forever and hang the test instead of failing it.
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(10*time.Second)))
+	require.NoError(t, serverConn.SetWriteDeadline(time.Now().Add(10*time.Second)))
+
+	type result struct {
+		texts int
+		bad   string
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		res := result{}
+		for {
+			f, err := ws.ReadFrame(clientConn)
+			if err != nil {
+				resCh <- res
+				return
+			}
+			if f.Header.OpCode != ws.OpText {
+				continue // control frames
+			}
+			res.texts++
+			if string(f.Payload) != "SIP" {
+				res.bad = string(f.Payload)
+				resCh <- res
+				return
+			}
+			if res.texts == writers*perWriter {
+				resCh <- res
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				if _, err := c.Write([]byte("SIP")); err != nil {
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	res := <-resCh
+	assert.Empty(t, res.bad, "frames interleaved on the wire, peer decoded a corrupt text frame")
+	assert.Equal(t, writers*perWriter, res.texts, "peer did not receive every SIP frame intact")
+
+	require.NoError(t, c.Close())
+	_ = clientConn.Close()
+}


### PR DESCRIPTION
Fixes #325

A Ping carrying a payload left those bytes in the stream, so the next header read started mid payload and the frame after the ping did not decode. `transport_ws.go:409` had the Ping arm commented out.

Control frames now go through `wsutil.ControlHandler`, which answers a Ping with a Pong carrying the same payload (RFC 6455 section 5.5.2), discards a Pong, and reads the payload out of the stream either way.

That introduces a second writer on the connection. `ws` writes a frame header and payload separately, so a Pong from the read goroutine can interleave with a concurrent `WriteMsg` and neither frame decodes. All frame writes now go through `writeFrame` under a mutex, and the lock is held across the control handler.

Tests cover a ping with a payload (asserting the following text frame still decodes), the empty-ping fast path, and 8 concurrent writers proving frames stay intact — the last one is meaningful under `-race`.