### PR TITLE
transport: keepalive ping on WS and WSS connections

### DIFF
--- a/sip/transport_ws.go
+++ b/sip/transport_ws.go
@@ -318,6 +318,27 @@ type WSConnection struct {
 	clientSide bool
 	mu         sync.RWMutex
 	refcount   int
+
+	// writeMu serializes frame writes on Conn. ws frame writing is not safe for
+	// concurrent use on a single net.Conn, and a Pong written from the read
+	// goroutine may race WriteMsg. Without this two frames can interleave on the
+	// wire and neither one decodes.
+	writeMu sync.Mutex
+}
+
+func (c *WSConnection) state() ws.State {
+	if c.clientSide {
+		return ws.StateClientSide
+	}
+	return ws.StateServerSide
+}
+
+// writeFrame writes a single frame. Every frame written on this connection must
+// go through here to keep writes serialized.
+func (c *WSConnection) writeFrame(f ws.Frame) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return ws.WriteFrame(c.Conn, f)
 }
 
 func (c *WSConnection) Ref(i int) int {
@@ -356,11 +377,24 @@ func (c *WSConnection) TryClose() (int, error) {
 	return ref, c.Conn.Close()
 }
 
+// handleControlFrame answers a Ping with a Pong and discards a Pong, reading the
+// control payload out of reader either way. The write lock is held across the
+// whole handler because it may write a header and payload separately, and those
+// must not be split by a concurrent Write.
+func (c *WSConnection) handleControlFrame(header ws.Header, reader io.Reader, state ws.State) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	return wsutil.ControlHandler{
+		Src: reader,
+		Dst: c.Conn,
+		// reader already unmasks the payload it yields.
+		DisableSrcCiphering: true,
+		State:               state,
+	}.Handle(header)
+}
+
 func (c *WSConnection) Read(b []byte) (n int, err error) {
-	state := ws.StateServerSide
-	if c.clientSide {
-		state = ws.StateClientSide
-	}
+	state := c.state()
 	reader := wsutil.NewReader(c.Conn, state)
 	reader.MaxFrameSize = int64(ParseMaxMessageLength)
 	for {
@@ -380,6 +414,12 @@ func (c *WSConnection) Read(b []byte) (n int, err error) {
 		if header.OpCode.IsControl() {
 			if header.OpCode == ws.OpClose {
 				return n, net.ErrClosed
+			}
+			// Ping must be answered with a Pong carrying the same payload, and
+			// any control payload must be read out of the stream, otherwise the
+			// next header read starts mid payload. See RFC 6455 section 5.5.
+			if err := c.handleControlFrame(header, reader, state); err != nil {
+				return n, err
 			}
 			continue
 		}
@@ -405,12 +445,6 @@ func (c *WSConnection) Read(b []byte) (n int, err error) {
 		if err != nil {
 			return n, err
 		}
-
-		// if header.OpCode == ws.OpPing {
-		// 	f := ws.NewPongFrame(data)
-		// 	ws.WriteFrame(c.Conn, f)
-		// 	continue
-		// }
 
 		if header.Masked {
 			ws.Cipher(data, header.Mask, 0)
@@ -440,7 +474,7 @@ func (c *WSConnection) Write(b []byte) (n int, err error) {
 	if c.clientSide {
 		fs = ws.MaskFrameInPlace(fs)
 	}
-	err = ws.WriteFrame(c.Conn, fs)
+	err = c.writeFrame(fs)
 
 	return len(b), err
 }

--- a/sip/transport_ws.go
+++ b/sip/transport_ws.go
@@ -20,6 +20,13 @@ var (
 	// WebSocketProtocols is used in setting websocket header
 	// By default clients must accept protocol sip
 	WebSocketProtocols = []string{"sip"}
+
+	// TransportWSKeepAlivePeriod sets how often a Ping frame is sent on an
+	// established WS or WSS connection. Proxies and load balancers commonly drop
+	// idle SIP over WebSocket connections after 30 to 60 seconds, and without
+	// traffic the connection goes stale without either side noticing. Set to 0
+	// to disable sending pings.
+	TransportWSKeepAlivePeriod = 20 * time.Second
 )
 
 // WS transport implementation
@@ -157,14 +164,11 @@ func (t *TransportWS) initConnection(conn net.Conn, raddr string, clientSide boo
 	// conn.SetKeepAlivePeriod(3 * time.Second)
 	laddr := conn.LocalAddr().String()
 	t.log.Debug("New WS connection", "raddr", raddr)
-	c := &WSConnection{
-		Conn:       conn,
-		refcount:   1 + TransportIdleConnection,
-		clientSide: clientSide,
-	}
+	c := newWSConnection(conn, clientSide, 1+TransportIdleConnection)
 	t.pool.Add(laddr, c)
 	t.pool.Add(raddr, c)
 	go t.readConnection(c, laddr, raddr, handler)
+	go c.keepalive(t.log)
 	return c
 }
 
@@ -297,12 +301,9 @@ func (t *TransportWS) CreateConnection(ctx context.Context, laddr Addr, raddr Ad
 		}
 
 		t.log.Debug("New WS connection", "raddr", raddr)
-		c := &WSConnection{
-			Conn:       conn,
-			refcount:   2 + TransportIdleConnection,
-			clientSide: true,
-		}
+		c := newWSConnection(conn, true, 2+TransportIdleConnection)
 		go t.readConnection(c, c.LocalAddr().String(), c.RemoteAddr().String(), handler)
+		go c.keepalive(t.log)
 		return c, nil
 	})
 	if err != nil {
@@ -320,10 +321,29 @@ type WSConnection struct {
 	refcount   int
 
 	// writeMu serializes frame writes on Conn. ws frame writing is not safe for
-	// concurrent use on a single net.Conn, and a Pong written from the read
-	// goroutine may race WriteMsg. Without this two frames can interleave on the
-	// wire and neither one decodes.
+	// concurrent use on a single net.Conn, and pings from the keepalive
+	// goroutine and pongs from the read goroutine may now race WriteMsg. Without
+	// this two frames can interleave on the wire and neither one decodes.
 	writeMu sync.Mutex
+
+	// closeCh is closed once the connection is hard closed, so that the
+	// keepalive goroutine stops.
+	closeCh   chan struct{}
+	closeOnce sync.Once
+}
+
+func newWSConnection(conn net.Conn, clientSide bool, refcount int) *WSConnection {
+	return &WSConnection{
+		Conn:       conn,
+		clientSide: clientSide,
+		refcount:   refcount,
+		closeCh:    make(chan struct{}),
+	}
+}
+
+// signalClose stops the keepalive goroutine. It is safe to call more than once.
+func (c *WSConnection) signalClose() {
+	c.closeOnce.Do(func() { close(c.closeCh) })
 }
 
 func (c *WSConnection) state() ws.State {
@@ -341,6 +361,40 @@ func (c *WSConnection) writeFrame(f ws.Frame) error {
 	return ws.WriteFrame(c.Conn, f)
 }
 
+// keepalive sends a Ping frame every TransportWSKeepAlivePeriod until the
+// connection is closed. A failed write means the connection is gone, so it is
+// closed to wake up the read goroutine and let the pool clean up.
+func (c *WSConnection) keepalive(log *slog.Logger) {
+	period := TransportWSKeepAlivePeriod
+	if period <= 0 {
+		return
+	}
+
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.closeCh:
+			return
+		case <-ticker.C:
+			f := ws.NewPingFrame(nil)
+			if c.clientSide {
+				f = ws.MaskFrameInPlace(f)
+			}
+			if err := c.writeFrame(f); err != nil {
+				log.Debug("WS keepalive ping failed, closing connection", "ip", c.RemoteAddr().String(), "error", err)
+				// Close only the underlying conn and leave the refcount alone, so
+				// the read goroutine wakes up and the pool runs its normal
+				// teardown for this connection.
+				if err := c.Conn.Close(); err != nil {
+					log.Debug("WS keepalive close failed", "ip", c.RemoteAddr().String(), "error", err)
+				}
+				return
+			}
+		}
+	}
+}
+
 func (c *WSConnection) Ref(i int) int {
 	c.mu.Lock()
 	c.refcount += i
@@ -356,6 +410,7 @@ func (c *WSConnection) Close() error {
 	c.refcount = 0
 	c.mu.Unlock()
 	DefaultLogger().Debug("WS doing hard close", "ip", c.RemoteAddr().String())
+	c.signalClose()
 	return c.Conn.Close()
 }
 
@@ -374,6 +429,7 @@ func (c *WSConnection) TryClose() (int, error) {
 		return 0, nil
 	}
 	DefaultLogger().Debug("WS closing", "ip", c.RemoteAddr().String(), "ref", ref)
+	c.signalClose()
 	return ref, c.Conn.Close()
 }
 

--- a/sip/transport_ws_test.go
+++ b/sip/transport_ws_test.go
@@ -44,7 +44,7 @@ func TestWSConnectionPingIsAnsweredWithPong(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	defer clientConn.Close()
 
-	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+	c := newWSConnection(serverConn, false, 1)
 	defer c.Close()
 
 	readCh := make(chan string, 1)
@@ -85,7 +85,7 @@ func TestWSConnectionEmptyPingIsAnsweredWithPong(t *testing.T) {
 	serverConn, clientConn := net.Pipe()
 	defer clientConn.Close()
 
-	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+	c := newWSConnection(serverConn, false, 1)
 	defer c.Close()
 
 	go func() {
@@ -102,16 +102,150 @@ func TestWSConnectionEmptyPingIsAnsweredWithPong(t *testing.T) {
 	assert.Empty(t, pong.Payload)
 }
 
-// TestWSConnectionConcurrentWrites exercises concurrent SIP writes on one
-// connection. Frames must not interleave on the wire, so every frame the peer
-// reads has to decode. Run with -race to also catch unsynchronized access to
-// the underlying conn.
+// TestWSConnectionKeepaliveSendsPing checks that an idle connection emits Ping
+// frames on the configured period.
+func TestWSConnectionKeepaliveSendsPing(t *testing.T) {
+	prev := TransportWSKeepAlivePeriod
+	TransportWSKeepAlivePeriod = 10 * time.Millisecond
+	t.Cleanup(func() { TransportWSKeepAlivePeriod = prev })
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	c := newWSConnection(serverConn, false, 1)
+	defer c.Close()
+	go c.keepalive(DefaultLogger())
+
+	f := mustReadFrame(t, readFrameAsync(t, clientConn))
+	assert.Equal(t, ws.OpPing, f.Header.OpCode)
+	assert.False(t, f.Header.Masked, "server side must not mask")
+}
+
+// TestWSConnectionKeepaliveMasksClientSide checks a client side connection masks
+// its Ping frames, as required for client to server frames.
+func TestWSConnectionKeepaliveMasksClientSide(t *testing.T) {
+	prev := TransportWSKeepAlivePeriod
+	TransportWSKeepAlivePeriod = 10 * time.Millisecond
+	t.Cleanup(func() { TransportWSKeepAlivePeriod = prev })
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	c := newWSConnection(serverConn, true, 1)
+	defer c.Close()
+	go c.keepalive(DefaultLogger())
+
+	f := mustReadFrame(t, readFrameAsync(t, clientConn))
+	assert.Equal(t, ws.OpPing, f.Header.OpCode)
+	assert.True(t, f.Header.Masked, "client side must mask")
+}
+
+// TestWSConnectionKeepaliveStopsOnClose checks the keepalive goroutine exits when
+// the connection is closed, rather than leaking for the process lifetime. The
+// period is long enough that the ticker cannot fire, so only Close can end it.
+func TestWSConnectionKeepaliveStopsOnClose(t *testing.T) {
+	prev := TransportWSKeepAlivePeriod
+	TransportWSKeepAlivePeriod = time.Hour
+	t.Cleanup(func() { TransportWSKeepAlivePeriod = prev })
+
+	for _, tc := range []struct {
+		name  string
+		close func(c *WSConnection)
+	}{
+		{"Close", func(c *WSConnection) { _ = c.Close() }},
+		{"TryClose", func(c *WSConnection) { _, _ = c.TryClose() }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+
+			c := newWSConnection(serverConn, false, 1)
+			done := make(chan struct{})
+			go func() {
+				c.keepalive(DefaultLogger())
+				close(done)
+			}()
+
+			tc.close(c)
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("keepalive goroutine leaked after close")
+			}
+		})
+	}
+}
+
+// TestWSConnectionKeepaliveExitsOnDeadPeer checks that when the peer is gone and
+// the ping write fails, the keepalive goroutine closes the connection and exits
+// instead of spinning on a dead link.
+func TestWSConnectionKeepaliveExitsOnDeadPeer(t *testing.T) {
+	prev := TransportWSKeepAlivePeriod
+	TransportWSKeepAlivePeriod = 10 * time.Millisecond
+	t.Cleanup(func() { TransportWSKeepAlivePeriod = prev })
+
+	serverConn, clientConn := net.Pipe()
+	c := newWSConnection(serverConn, false, 1)
+
+	done := make(chan struct{})
+	go func() {
+		c.keepalive(DefaultLogger())
+		close(done)
+	}()
+
+	// Peer disappears. The pipe write then fails rather than blocking.
+	require.NoError(t, clientConn.Close())
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("keepalive did not exit after ping write failed")
+	}
+
+	// The connection must be closed so the read goroutine wakes up.
+	_, err := serverConn.Read(make([]byte, 1))
+	assert.Error(t, err)
+}
+
+// TestWSConnectionKeepaliveDisabled checks a zero period turns pings off.
+func TestWSConnectionKeepaliveDisabled(t *testing.T) {
+	prev := TransportWSKeepAlivePeriod
+	TransportWSKeepAlivePeriod = 0
+	t.Cleanup(func() { TransportWSKeepAlivePeriod = prev })
+
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	c := newWSConnection(serverConn, false, 1)
+	defer c.Close()
+
+	done := make(chan struct{})
+	go func() {
+		c.keepalive(DefaultLogger())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("keepalive should return immediately when disabled")
+	}
+}
+
+// TestWSConnectionConcurrentWrites exercises pings racing SIP writes. Frames must
+// not interleave on the wire, so every frame the peer reads has to decode. Run
+// with -race to also catch unsynchronized access to the underlying conn.
 func TestWSConnectionConcurrentWrites(t *testing.T) {
+	prev := TransportWSKeepAlivePeriod
+	TransportWSKeepAlivePeriod = time.Millisecond
+	t.Cleanup(func() { TransportWSKeepAlivePeriod = prev })
+
 	const writers, perWriter = 8, 50
 
 	serverConn, clientConn := net.Pipe()
 
-	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+	c := newWSConnection(serverConn, false, 1)
+	go c.keepalive(DefaultLogger())
 
 	// Deadlines bound both ends. If writes interleave the peer sees a corrupt
 	// frame and stops reading, which would otherwise block the writers on the
@@ -133,7 +267,7 @@ func TestWSConnectionConcurrentWrites(t *testing.T) {
 				return
 			}
 			if f.Header.OpCode != ws.OpText {
-				continue // control frames
+				continue // keepalive pings
 			}
 			res.texts++
 			if string(f.Payload) != "SIP" {

--- a/sip/transport_ws_test.go
+++ b/sip/transport_ws_test.go
@@ -1,0 +1,171 @@
+package sip
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readFrameAsync reads one frame from conn without blocking the caller.
+func readFrameAsync(t *testing.T, conn net.Conn) <-chan ws.Frame {
+	t.Helper()
+	ch := make(chan ws.Frame, 1)
+	go func() {
+		f, err := ws.ReadFrame(conn)
+		if err != nil {
+			return
+		}
+		ch <- f
+	}()
+	return ch
+}
+
+func mustReadFrame(t *testing.T, ch <-chan ws.Frame) ws.Frame {
+	t.Helper()
+	select {
+	case f := <-ch:
+		return f
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for frame")
+		return ws.Frame{}
+	}
+}
+
+// TestWSConnectionPingIsAnsweredWithPong checks RFC 6455 section 5.5.2: a Pong
+// must carry the same payload as the Ping it answers. The text frame sent after
+// the ping must still decode, which only holds if the ping payload was read out
+// of the stream instead of being left for the next header read.
+func TestWSConnectionPingIsAnsweredWithPong(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+	defer c.Close()
+
+	readCh := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 1024)
+		n, err := c.Read(buf)
+		if err != nil {
+			return
+		}
+		readCh <- string(buf[:n])
+	}()
+
+	// Client side must mask its frames.
+	go func() {
+		ping := ws.MaskFrameInPlace(ws.NewPingFrame([]byte("keepalive")))
+		if err := ws.WriteFrame(clientConn, ping); err != nil {
+			return
+		}
+		text := ws.MaskFrameInPlace(ws.NewTextFrame([]byte("OPTIONS sip:x SIP/2.0\r\n\r\n")))
+		_ = ws.WriteFrame(clientConn, text)
+	}()
+
+	pong := mustReadFrame(t, readFrameAsync(t, clientConn))
+	assert.Equal(t, ws.OpPong, pong.Header.OpCode)
+	assert.Equal(t, []byte("keepalive"), pong.Payload, "pong must echo the ping payload")
+
+	select {
+	case got := <-readCh:
+		assert.Equal(t, "OPTIONS sip:x SIP/2.0\r\n\r\n", got, "text frame after ping must still decode")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: stream desynced after ping with payload")
+	}
+}
+
+// TestWSConnectionEmptyPingIsAnsweredWithPong covers the common empty ping,
+// which the control handler answers on a header-only fast path.
+func TestWSConnectionEmptyPingIsAnsweredWithPong(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	defer clientConn.Close()
+
+	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+	defer c.Close()
+
+	go func() {
+		buf := make([]byte, 1024)
+		_, _ = c.Read(buf)
+	}()
+
+	go func() {
+		_ = ws.WriteFrame(clientConn, ws.MaskFrameInPlace(ws.NewPingFrame(nil)))
+	}()
+
+	pong := mustReadFrame(t, readFrameAsync(t, clientConn))
+	assert.Equal(t, ws.OpPong, pong.Header.OpCode)
+	assert.Empty(t, pong.Payload)
+}
+
+// TestWSConnectionConcurrentWrites exercises concurrent SIP writes on one
+// connection. Frames must not interleave on the wire, so every frame the peer
+// reads has to decode. Run with -race to also catch unsynchronized access to
+// the underlying conn.
+func TestWSConnectionConcurrentWrites(t *testing.T) {
+	const writers, perWriter = 8, 50
+
+	serverConn, clientConn := net.Pipe()
+
+	c := &WSConnection{Conn: serverConn, clientSide: false, refcount: 1}
+
+	// Deadlines bound both ends. If writes interleave the peer sees a corrupt
+	// frame and stops reading, which would otherwise block the writers on the
+	// unbuffered pipe forever and hang the test instead of failing it.
+	require.NoError(t, clientConn.SetReadDeadline(time.Now().Add(10*time.Second)))
+	require.NoError(t, serverConn.SetWriteDeadline(time.Now().Add(10*time.Second)))
+
+	type result struct {
+		texts int
+		bad   string
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		res := result{}
+		for {
+			f, err := ws.ReadFrame(clientConn)
+			if err != nil {
+				resCh <- res
+				return
+			}
+			if f.Header.OpCode != ws.OpText {
+				continue // control frames
+			}
+			res.texts++
+			if string(f.Payload) != "SIP" {
+				res.bad = string(f.Payload)
+				resCh <- res
+				return
+			}
+			if res.texts == writers*perWriter {
+				resCh <- res
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				if _, err := c.Write([]byte("SIP")); err != nil {
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	res := <-resCh
+	assert.Empty(t, res.bad, "frames interleaved on the wire, peer decoded a corrupt text frame")
+	assert.Equal(t, writers*perWriter, res.texts, "peer did not receive every SIP frame intact")
+
+	require.NoError(t, c.Close())
+	_ = clientConn.Close()
+}

--- a/sip/transport_wss.go
+++ b/sip/transport_wss.go
@@ -108,12 +108,9 @@ func (t *TransportWSS) CreateConnection(ctx context.Context, laddr Addr, raddr A
 			return nil, fmt.Errorf("failed to upgrade: %w", err)
 		}
 
-		c := &WSConnection{
-			Conn:       tlsConn,
-			refcount:   2 + TransportIdleConnection,
-			clientSide: true,
-		}
+		c := newWSConnection(tlsConn, true, 2+TransportIdleConnection)
 		go t.readConnection(c, c.LocalAddr().String(), c.RemoteAddr().String(), handler)
+		go c.keepalive(t.log)
 		return c, nil
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #327

Stacked on #326 — it needs the serialized `writeFrame` from that PR, so the diff here shows only the keepalive on top. Please take #326 first.

Proxies and load balancers commonly drop idle SIP over WebSocket connections after 30 to 60 seconds. Nothing generates traffic on an idle connection, so neither side notices until a call fails on one that is already gone.

WS and WSS connections now start a goroutine alongside the read goroutine that sends a Ping every `TransportWSKeepAlivePeriod`, default 20s. A non-positive period disables it. A failed ping write means the connection is gone, so only the underlying conn is closed and the refcount is left alone — the read goroutine wakes and the pool runs its normal teardown. The goroutine stops on `Close` and `TryClose`.

It is on by default and costs one goroutine per WS/WSS connection, which is why it is separate from the fix in #326 rather than bundled with it.

Tests cover the period firing, client-side masking, exit on `Close`/`TryClose`, exit on a dead peer, and the disabled case.