### PR TITLE
dialog: answer a stale nonce re-challenge on INVITE

### DIFF
--- a/dialog_client.go
+++ b/dialog_client.go
@@ -228,6 +228,12 @@ var (
 	WaitAnswerForceCancelErr = errors.New("Context cancel forced")
 )
 
+// maxAuthAttempts caps how many digest challenges are answered on one INVITE.
+// Two allows a stale=true re-challenge (RFC 2617 3.2.1, adopted for SIP by RFC
+// 3261 22.4) to be answered with the
+// fresh nonce, while still terminating an endless challenge stream.
+const maxAuthAttempts = 2
+
 // WaitAnswer waits for success response or returns ErrDialogResponse in case non 2xx
 // Canceling context while waiting 2xx will send Cancel request. It will block until 1xx provisional is not received
 // If Canceling succesfull context.Canceled error is returned
@@ -238,6 +244,9 @@ func (s *DialogClientSession) WaitAnswer(ctx context.Context, opts AnswerOptions
 	tx, inviteRequest := s.inviteTx, s.InviteRequest
 	var r *sip.Response
 	var err error
+	// Counts challenges answered on this INVITE, shared by both arms so that a
+	// 407 followed by a 401 consumes both attempts.
+	authAttempts := 0
 	for i := 0; ; i++ {
 		if i > 10 {
 			// Preventing some long loops
@@ -274,62 +283,73 @@ func (s *DialogClientSession) WaitAnswer(ctx context.Context, opts AnswerOptions
 			continue
 		}
 
-		if (r.StatusCode == sip.StatusProxyAuthRequired) && opts.Password != "" {
-			h := inviteRequest.GetHeader("Proxy-Authorization")
-			if h == nil {
-				tx.Terminate()
+		// A 401/407 is a challenge only when it actually carries the authenticate
+		// header. A peer is free to answer either with no challenge at all as a
+		// plain rejection, and a challenge that is not there cannot be answered:
+		// such a response falls through to the final response below and reaches
+		// the caller with its real status, instead of a digest parse error that
+		// replaces it.
+		//
+		// Retrying is bounded by maxAuthAttempts rather than by the absence of an
+		// authorization header on the request. The latter permits exactly one
+		// attempt, so a stale=true re-challenge was rejected as a hard failure.
+		// Replacing is safe because digest*AuthApply removes the existing
+		// authorization header before appending, so the aged credential is
+		// replaced rather than stacked.
+		if r.StatusCode == sip.StatusProxyAuthRequired && opts.Password != "" &&
+			r.GetHeader("Proxy-Authenticate") != nil && authAttempts < maxAuthAttempts {
+			authAttempts++
+			tx.Terminate()
 
-				digopts := digest.Options{
-					Method:   sip.INVITE.String(),
-					URI:      inviteRequest.Recipient.Addr(),
-					Username: opts.Username,
-					Password: opts.Password,
-				}
-
-				// First build this request
-				if err := digestProxyAuthApply(inviteRequest, r, digopts); err != nil {
-					return err
-				}
-
-				// Remove Via from original request and send it through dialog transaction
-				// This keeps transaction within dialog
-				inviteRequest.RemoveHeader("Via")
-				tx, err = s.TransactionRequest(ctx, inviteRequest)
-				if err != nil {
-					return err
-				}
-				s.inviteTx = tx // We need to update this here as we can exit early like on provisional
-				continue
+			digopts := digest.Options{
+				Method:   sip.INVITE.String(),
+				URI:      inviteRequest.Recipient.Addr(),
+				Username: opts.Username,
+				Password: opts.Password,
 			}
+
+			// First build this request
+			if err := digestProxyAuthApply(inviteRequest, r, digopts); err != nil {
+				return err
+			}
+
+			// Remove Via from original request and send it through dialog transaction
+			// This keeps transaction within dialog
+			inviteRequest.RemoveHeader("Via")
+			tx, err = s.TransactionRequest(ctx, inviteRequest)
+			if err != nil {
+				return err
+			}
+			s.inviteTx = tx // We need to update this here as we can exit early like on provisional
+			continue
 		}
 
-		if r.StatusCode == sip.StatusUnauthorized && opts.Password != "" {
-			h := inviteRequest.GetHeader("Authorization")
-			if h == nil {
-				tx.Terminate()
+		if r.StatusCode == sip.StatusUnauthorized && opts.Password != "" &&
+			r.GetHeader("WWW-Authenticate") != nil && authAttempts < maxAuthAttempts {
+			authAttempts++
+			tx.Terminate()
 
-				digopts := digest.Options{
-					Method:   sip.INVITE.String(),
-					URI:      inviteRequest.Recipient.Addr(),
-					Username: opts.Username,
-					Password: opts.Password,
-				}
-
-				// First build this request
-				if err := digestAuthApply(inviteRequest, r, digopts); err != nil {
-					return err
-				}
-
-				// Remove Via from original request and send it through dialog transaction
-				// This keeps transaction within dialog
-				inviteRequest.RemoveHeader("Via")
-				tx, err = s.TransactionRequest(ctx, inviteRequest)
-				if err != nil {
-					return err
-				}
-				s.inviteTx = tx // We need to update this here as we can exit early like on provisional
-				continue
+			digopts := digest.Options{
+				Method:   sip.INVITE.String(),
+				URI:      inviteRequest.Recipient.Addr(),
+				Username: opts.Username,
+				Password: opts.Password,
 			}
+
+			// First build this request
+			if err := digestAuthApply(inviteRequest, r, digopts); err != nil {
+				return err
+			}
+
+			// Remove Via from original request and send it through dialog transaction
+			// This keeps transaction within dialog
+			inviteRequest.RemoveHeader("Via")
+			tx, err = s.TransactionRequest(ctx, inviteRequest)
+			if err != nil {
+				return err
+			}
+			s.inviteTx = tx // We need to update this here as we can exit early like on provisional
+			continue
 		}
 
 		return &ErrDialogResponse{Res: r}
@@ -500,11 +520,11 @@ func newAckRequestUAC(inviteRequest *sip.Request, inviteResponse *sip.Response, 
 	ackRequest.SipVersion = inviteRequest.SipVersion
 
 	// ACK to 2xx response should not copy over Route header(s) from original INVITE request.
-	// Instead the ACK should include Route header(s) derived from reversing the order of 
-	// Record-Route header(s) in the 2xx response. 
+	// Instead the ACK should include Route header(s) derived from reversing the order of
+	// Record-Route header(s) in the 2xx response.
 	// https://datatracker.ietf.org/doc/html/rfc3261#section-12.1.2
 	// https://datatracker.ietf.org/doc/html/rfc3261#section-12.2.1.1
-	
+
 	if h := inviteRequest.From(); h != nil {
 		ackRequest.AppendHeader(sip.HeaderClone(h))
 	}

--- a/dialog_client_test.go
+++ b/dialog_client_test.go
@@ -212,6 +212,84 @@ func TestDialogClientMultiResponses(t *testing.T) {
 		assert.Equal(t, d.InviteRequest.CSeq().SeqNo, sentReq.CSeq().SeqNo)
 	})
 
+	// A nonce the server considers aged is re-challenged with stale=true and a
+	// fresh nonce. RFC 2617 3.2.1 defines stale, and RFC 3261 22.4 adopts the
+	// digest scheme for SIP; the UAC answers with the new
+	// nonce instead of treating it as a rejection.
+	t.Run("StaleNonceRechallenge", func(t *testing.T) {
+		challenges := 0
+		client := testClient(t, func(req *sip.Request) *sip.Response {
+			if challenges >= 2 {
+				return sip.NewResponseFromRequest(req, 200, "OK", nil)
+			}
+			challenges++
+			res := sip.NewResponseFromRequest(req, 401, "Unauthorized", nil)
+			// Second challenge carries stale=true and a different nonce.
+			nonce, stale := "662d65a084b88c6d2a745a9de086fa91", ""
+			if challenges == 2 {
+				nonce, stale = "9f3c1e7b2d4a5068cb1e0d7a3f6b2c84", `, stale=true`
+			}
+			challenge := `Digest realm="test", nonce="` + nonce + `", algorithm=MD5` + stale
+			res.AppendHeader(sip.NewHeader("WWW-Authenticate", challenge))
+			return res
+		})
+
+		dua := DialogUA{
+			Client: client,
+		}
+		d, err := dua.Invite(context.TODO(), sip.Uri{User: "test", Host: "localhost"}, nil)
+		require.NoError(t, err)
+
+		err = d.WaitAnswer(context.TODO(), AnswerOptions{Username: "user", Password: "secret"})
+		require.NoError(t, err)
+		assert.Equal(t, 2, challenges)
+		// The re-challenge must be answered with the fresh nonce, and the aged
+		// credential replaced rather than stacked.
+		auth := d.InviteRequest.GetHeaders("Authorization")
+		require.Len(t, auth, 1)
+		assert.Contains(t, auth[0].Value(), "9f3c1e7b2d4a5068cb1e0d7a3f6b2c84")
+	})
+
+	// An endless challenge stream must still terminate, and must terminate as a
+	// plain non-2xx final response carrying the real status.
+	t.Run("AuthLoopTerminatesAsDialogResponse", func(t *testing.T) {
+		client := testClient(t, func(req *sip.Request) *sip.Response {
+			res := sip.NewResponseFromRequest(req, 401, "Unauthorized", nil)
+			challenge := `Digest realm="test", nonce="662d65a084b88c6d2a745a9de086fa91", algorithm=MD5, stale=true`
+			res.AppendHeader(sip.NewHeader("WWW-Authenticate", challenge))
+			return res
+		})
+
+		dua := DialogUA{
+			Client: client,
+		}
+		d, err := dua.Invite(context.TODO(), sip.Uri{User: "test", Host: "localhost"}, nil)
+		require.NoError(t, err)
+
+		err = d.WaitAnswer(context.TODO(), AnswerOptions{Username: "user", Password: "secret"})
+		var resErr *ErrDialogResponse
+		require.ErrorAs(t, err, &resErr)
+		assert.Equal(t, 401, resErr.Res.StatusCode)
+	})
+
+	// A 401 with no WWW-Authenticate is a plain rejection, not a challenge. It
+	// must reach the caller as its real response, not as a digest parse error.
+	t.Run("AuthNoChallenge", func(t *testing.T) {
+		client := testClient(t, func(req *sip.Request) *sip.Response {
+			return sip.NewResponseFromRequest(req, 401, "Unauthorized", nil)
+		})
+
+		dua := DialogUA{
+			Client: client,
+		}
+		d, err := dua.Invite(context.TODO(), sip.Uri{User: "test", Host: "localhost"}, nil)
+		require.NoError(t, err)
+
+		err = d.WaitAnswer(context.TODO(), AnswerOptions{Username: "user", Password: "secret"})
+		var resErr *ErrDialogResponse
+		require.ErrorAs(t, err, &resErr)
+		assert.Equal(t, 401, resErr.Res.StatusCode)
+	})
 }
 
 func TestDialogClientACKRetransmission(t *testing.T) {


### PR DESCRIPTION
Fixes #329

`WaitAnswer` guarded the digest retry on the absence of an `Authorization` header, so after the first attempt a second 401 was never treated as a challenge. That guard was also doing loop-termination duty, which is why it could not answer a re-challenge.

A `stale=true` re-challenge (RFC 2617 3.2.1, adopted for SIP by RFC 3261 22.4) asks the UAC to retry with the new nonce and the same credentials, so a registrar rotating nonces failed the INVITE on a correct password.

Attempts are counted instead, capped at two and shared by the 401 and 407 arms so a 407 followed by a 401 consumes both. Replacing credentials is safe because `digestAuthApply` and `digestProxyAuthApply` remove the existing authorization header before appending.

A 401/407 is treated as a challenge only when it carries the matching authenticate header, so a plain rejection reaches the caller as its own status rather than "No WWW-Authenticate header present".

**No new exported API** — `maxAuthAttempts` is unexported and exhausting the cap returns the same `ErrDialogResponse` as today, so terminal behaviour is unchanged for existing callers. Your `AuthLoop` subtest passes unmodified; three subtests are added alongside it for the stale re-challenge, cap exhaustion, and the no-challenge case.