### PR TITLE
transport: configurable write and read timeouts on TCP transport

### DIFF
--- a/fakes/tcp_conn.go
+++ b/fakes/tcp_conn.go
@@ -19,6 +19,7 @@ type TCPConn struct {
 	mu sync.Mutex
 
 	writeDeadlines []time.Time
+	readDeadlines  []time.Time
 }
 
 // SetWriteDeadline records the deadline instead of enforcing it. The embedded
@@ -35,6 +36,22 @@ func (c *TCPConn) WriteDeadlines() []time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return append([]time.Time(nil), c.writeDeadlines...)
+}
+
+// SetReadDeadline records the deadline instead of enforcing it. The embedded
+// net.Conn is nil on this fake, so the call must not be forwarded.
+func (c *TCPConn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.readDeadlines = append(c.readDeadlines, t)
+	c.mu.Unlock()
+	return nil
+}
+
+// ReadDeadlines returns the deadlines passed to SetReadDeadline so far.
+func (c *TCPConn) ReadDeadlines() []time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Time(nil), c.readDeadlines...)
 }
 
 // func (c *TCPConn) ExpectAddr(addr net.TCPAddr) {

--- a/fakes/tcp_conn.go
+++ b/fakes/tcp_conn.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 )
 
 type TCPConn struct {
@@ -16,6 +17,24 @@ type TCPConn struct {
 	Writer io.Writer
 
 	mu sync.Mutex
+
+	writeDeadlines []time.Time
+}
+
+// SetWriteDeadline records the deadline instead of enforcing it. The embedded
+// net.Conn is nil on this fake, so the call must not be forwarded.
+func (c *TCPConn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	c.writeDeadlines = append(c.writeDeadlines, t)
+	c.mu.Unlock()
+	return nil
+}
+
+// WriteDeadlines returns the deadlines passed to SetWriteDeadline so far.
+func (c *TCPConn) WriteDeadlines() []time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Time(nil), c.writeDeadlines...)
 }
 
 // func (c *TCPConn) ExpectAddr(addr net.TCPAddr) {

--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -32,6 +32,19 @@ type TransportTCP struct {
 	// treat as a transport failure rather than a fatal one.
 	WriteTimeout time.Duration
 
+	// ReadTimeout bounds how long a connection of this transport may sit
+	// without a readable byte. Zero, the default, applies no deadline and lets
+	// a connection idle forever. When positive, every read arms
+	// SetReadDeadline(now + ReadTimeout) and exceeding it closes the
+	// connection, leaving the peer free to reconnect.
+	//
+	// The message size caps bound how much memory one message may cost; this
+	// bounds the peer in time instead. A peer that opens a connection and then
+	// sends nothing, or stalls midway through a message, otherwise holds a
+	// goroutine, a socket and a read buffer indefinitely. RFC 5626 keep-alives
+	// reset the deadline, so a healthy long lived connection never reaches it.
+	ReadTimeout time.Duration
+
 	onConnClose func(conn Connection)
 }
 
@@ -176,10 +189,25 @@ func (t *TransportTCP) readConnection(conn *TCPConnection, laddr string, raddr s
 	par := t.parser.NewSIPStream()
 
 	for {
+		if d := t.ReadTimeout; d > 0 {
+			if err := conn.SetReadDeadline(time.Now().Add(d)); err != nil {
+				t.log.Debug("failed to arm read deadline", "error", err)
+			}
+		}
+
 		num, err := conn.Read(buf)
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
 				t.log.Debug("connection was closed", "error", err)
+				return
+			}
+
+			// The deferred CloseAndDelete tears the connection down and the peer
+			// is free to reconnect.
+			var ne net.Error
+			if errors.As(err, &ne) && ne.Timeout() {
+				t.log.Info("connection idle past read deadline, closing",
+					"raddr", raddr, "timeout", t.ReadTimeout)
 				return
 			}
 

--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -24,6 +24,14 @@ type TransportTCP struct {
 
 	DialerCreate func(laddr net.Addr) net.Dialer
 
+	// WriteTimeout bounds how long a single write on a connection of this
+	// transport may block on a peer that is not draining its receive window.
+	// Zero, the default, applies no deadline and keeps writes unbounded.
+	// When positive, every write arms SetWriteDeadline(now + WriteTimeout) and
+	// exceeding it fails the write with a timeout error, which callers already
+	// treat as a transport failure rather than a fatal one.
+	WriteTimeout time.Duration
+
 	onConnClose func(conn Connection)
 }
 
@@ -117,8 +125,9 @@ func (t *TransportTCP) CreateConnection(ctx context.Context, laddr Addr, raddr A
 
 		t.log.Debug("New connection", "raddr", raddr)
 		c := &TCPConnection{
-			Conn:     conn,
-			refcount: 2 + TransportIdleConnection, // 1 returning + 1 reading + Idle
+			Conn:         conn,
+			writeTimeout: t.WriteTimeout,
+			refcount:     2 + TransportIdleConnection, // 1 returning + 1 reading + Idle
 		}
 
 		go t.readConnection(c, c.LocalAddr().String(), c.RemoteAddr().String(), handler)
@@ -138,8 +147,9 @@ func (t *TransportTCP) initConnection(conn net.Conn, raddr string, handler Messa
 	laddr := conn.LocalAddr().String()
 	t.log.Debug("New connection", "raddr", raddr)
 	c := &TCPConnection{
-		Conn:     conn,
-		refcount: 1 + TransportIdleConnection,
+		Conn:         conn,
+		writeTimeout: t.WriteTimeout,
+		refcount:     1 + TransportIdleConnection,
 	}
 	t.pool.Add(laddr, c)
 	t.pool.Add(raddr, c)
@@ -242,6 +252,10 @@ func (t *TransportTCP) parseStream(par *ParserStream, data []byte, src string, h
 type TCPConnection struct {
 	net.Conn
 
+	// writeTimeout is copied from the transport at construction and never
+	// changes for the life of the connection. Zero means no write deadline.
+	writeTimeout time.Duration
+
 	mu       sync.RWMutex
 	refcount int
 }
@@ -292,6 +306,12 @@ func (c *TCPConnection) Read(b []byte) (n int, err error) {
 }
 
 func (c *TCPConnection) Write(b []byte) (n int, err error) {
+	if c.writeTimeout > 0 {
+		// Bound a peer that stopped draining. TLS shares this Conn.
+		if err := c.Conn.SetWriteDeadline(time.Now().Add(c.writeTimeout)); err != nil {
+			return 0, err
+		}
+	}
 	// Some debug hook. TODO move to proper way
 	n, err = c.Conn.Write(b)
 	if SIPDebug {

--- a/sip/transport_tcp_test.go
+++ b/sip/transport_tcp_test.go
@@ -76,6 +76,63 @@ func TestTransportTCPWriteTimeoutPropagates(t *testing.T) {
 	}
 }
 
+// TestTransportTCPReadTimeout checks that the read loop only arms a read
+// deadline when the transport was configured with a positive ReadTimeout. The
+// zero value must stay a strict no-op so existing users see no change.
+func TestTransportTCPReadTimeout(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		tp := &TransportTCP{}
+		tp.init(NewParser())
+		defer tp.Close()
+
+		fc := newFakeTCPConn()
+		tp.readConnection(&TCPConnection{Conn: fc}, fc.LocalAddr().String(), fc.RemoteAddr().String(), func(msg Message) {})
+
+		if got := fc.ReadDeadlines(); len(got) != 0 {
+			t.Fatalf("expected no read deadline armed, got %v", got)
+		}
+	})
+
+	t.Run("armed when set", func(t *testing.T) {
+		tp := &TransportTCP{ReadTimeout: 30 * time.Second}
+		tp.init(NewParser())
+		defer tp.Close()
+
+		fc := newFakeTCPConn()
+		tp.readConnection(&TCPConnection{Conn: fc}, fc.LocalAddr().String(), fc.RemoteAddr().String(), func(msg Message) {})
+
+		if got := fc.ReadDeadlines(); len(got) == 0 {
+			t.Fatal("expected a read deadline to be armed")
+		}
+	})
+}
+
+// TestTransportTCPReadTimeoutIdlePeer drives a real net.Pipe, which honors
+// deadlines, to show that a peer which connects and then sends nothing is
+// dropped rather than holding the read goroutine forever.
+func TestTransportTCPReadTimeoutIdlePeer(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	tp := &TransportTCP{ReadTimeout: 50 * time.Millisecond}
+	tp.init(NewParser())
+	defer tp.Close()
+
+	done := make(chan struct{})
+	go func() {
+		// client never writes, so the read blocks until the deadline fires
+		tp.readConnection(&TCPConnection{Conn: server}, "127.0.0.1:5060", "127.0.0.2:5060", func(msg Message) {})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("read loop did not return: an idle peer held the goroutine open")
+	}
+}
+
 // TestTCPConnectionWriteTimeoutStalledPeer drives a real net.Pipe, which
 // honors deadlines, to show that a write to a peer that never reads fails with
 // a timeout instead of blocking the writer forever.

--- a/sip/transport_tcp_test.go
+++ b/sip/transport_tcp_test.go
@@ -1,0 +1,107 @@
+package sip
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/emiago/sipgo/fakes"
+)
+
+func newFakeTCPConn() *fakes.TCPConn {
+	return &fakes.TCPConn{
+		LAddr:  net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5060},
+		RAddr:  net.TCPAddr{IP: net.ParseIP("127.0.0.2"), Port: 5060},
+		Reader: bytes.NewReader(nil),
+		Writer: io.Discard,
+	}
+}
+
+// TestTCPConnectionWriteTimeout checks that a connection only arms a write
+// deadline when the transport was configured with a positive WriteTimeout.
+// The zero value must stay a strict no-op so existing users see no change.
+func TestTCPConnectionWriteTimeout(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		fc := newFakeTCPConn()
+		c := &TCPConnection{Conn: fc}
+
+		if _, err := c.Write([]byte("OPTIONS sip:example.com SIP/2.0\r\n")); err != nil {
+			t.Fatalf("write err=%v", err)
+		}
+
+		if got := fc.WriteDeadlines(); len(got) != 0 {
+			t.Fatalf("zero WriteTimeout must not arm a deadline, got %d calls", len(got))
+		}
+	})
+
+	t.Run("arms deadline when configured", func(t *testing.T) {
+		fc := newFakeTCPConn()
+		c := &TCPConnection{Conn: fc, writeTimeout: time.Minute}
+
+		before := time.Now()
+		if _, err := c.Write([]byte("REGISTER sip:example.com SIP/2.0\r\n")); err != nil {
+			t.Fatalf("write err=%v", err)
+		}
+		after := time.Now()
+
+		got := fc.WriteDeadlines()
+		if len(got) != 1 {
+			t.Fatalf("expected exactly one deadline armed, got %d", len(got))
+		}
+		// Deadline must land in [before+timeout, after+timeout].
+		if got[0].Before(before.Add(time.Minute)) || got[0].After(after.Add(time.Minute)) {
+			t.Fatalf("deadline %v not within one minute of the write", got[0])
+		}
+	})
+}
+
+// TestTransportTCPWriteTimeoutPropagates checks that the transport hands its
+// WriteTimeout to the connections it accepts, which is what makes the field
+// reachable through TransportsConfig.
+func TestTransportTCPWriteTimeoutPropagates(t *testing.T) {
+	tp := &TransportTCP{WriteTimeout: 3 * time.Second}
+	tp.init(NewParser())
+	defer tp.Close()
+
+	fc := newFakeTCPConn()
+	conn := tp.initConnection(fc, fc.RemoteAddr().String(), func(msg Message) {})
+
+	got := conn.(*TCPConnection).writeTimeout
+	if got != 3*time.Second {
+		t.Fatalf("expected connection to inherit WriteTimeout, got %v", got)
+	}
+}
+
+// TestTCPConnectionWriteTimeoutStalledPeer drives a real net.Pipe, which
+// honors deadlines, to show that a write to a peer that never reads fails with
+// a timeout instead of blocking the writer forever.
+func TestTCPConnectionWriteTimeoutStalledPeer(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close() // never read from
+
+	c := &TCPConnection{Conn: client, writeTimeout: 50 * time.Millisecond}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := c.Write([]byte("INVITE sip:example.com SIP/2.0\r\n"))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected stalled write to fail once the deadline passed")
+		}
+		var ne net.Error
+		if !errors.Is(err, os.ErrDeadlineExceeded) && !(errors.As(err, &ne) && ne.Timeout()) {
+			t.Fatalf("expected a timeout error, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("write was not bounded by the deadline")
+	}
+}

--- a/sip/transport_tls.go
+++ b/sip/transport_tls.go
@@ -76,8 +76,9 @@ func (t *TransportTLS) CreateConnection(ctx context.Context, laddr Addr, raddr A
 
 		t.log.Debug("New connection", "raddr", raddr)
 		c := &TCPConnection{
-			Conn:     tlsConn,
-			refcount: 2 + TransportIdleConnection,
+			Conn:         tlsConn,
+			writeTimeout: t.WriteTimeout,
+			refcount:     2 + TransportIdleConnection,
 		}
 		isNew = true
 		return c, nil


### PR DESCRIPTION
Picks up #268, in the shape you asked for there:

> Right now you can customize transports trhough `TransportsConfig` which can be passed through `UA` on TransportLayer. What we basically need is to add those options somowhere in tcp transport.

`TransportTCP` gains `WriteTimeout` and `ReadTimeout`, so both are reachable through `TransportsConfig` with no package globals. `TransportTLS` embeds `*TransportTCP`, so its dial path copies `WriteTimeout` into the connection it builds and it picks up `ReadTimeout` by reusing `readConnection`.

Zero is the default and arms no deadline on either path, so this is a no-op for every existing user — which is the answer to "I find this very hardcoded": nothing is hardcoded and nothing changes unless a caller sets it.

**Write side.** A write to a peer that stops draining its receive window blocks the sending goroutine indefinitely. When `WriteTimeout` is positive, each write arms `SetWriteDeadline`.

**Read side.** A peer that opens a connection and sends nothing, or stalls midway through a message, holds a goroutine, a socket and a read buffer for as long as it likes. `ParseMaxMessageLength` bounds how much memory one message costs but nothing bounded a peer in time. The read loop arms `SetReadDeadline` per iteration and returns on a `net.Error` reporting `Timeout()`, after which the existing deferred `pool.CloseAndDelete` tears the connection down. RFC 5626 keep-alives reset the deadline, so a healthy long-lived connection never reaches it.

On the "could TCP keep alive solve it" question from #268 — it does not cover the write side at all, and on the read side it only detects a *dead* peer, not a live one that is deliberately slow or silent. That is the case these bound.

Credit to @j-licht for #268, whose diff this supersedes. Happy to close this if you would rather they carry it.

Tests cover both timeouts, propagation from transport to connection, an idle peer releasing the read goroutine over a real `net.Pipe`, and a stalled peer on the write side.