### PR TITLE
sip: add Session-Expires and Min-SE headers

### DIFF
--- a/sip/headers.go
+++ b/sip/headers.go
@@ -443,6 +443,27 @@ func (hs *headers) ReferredBy() *ReferredByHeader {
 	return nil
 }
 
+// SessionExpires parses underlying RFC 4028 Session-Expires header or nil if not
+// exists. Nil is also returned when the value is malformed, which is the read
+// side of a peer that offers no session timers: the dialog then runs with no
+// refresh loop instead of failing.
+func (hs *headers) SessionExpires() *SessionExpiresHeader {
+	h := &SessionExpiresHeader{}
+	if parseHeaderLazy(hs, parseSessionExpiresHeader, []string{"session-expires", "x"}, h) {
+		return h
+	}
+	return nil
+}
+
+// MinSE parses underlying RFC 4028 Min-SE header or nil if not exists.
+func (hs *headers) MinSE() *MinSEHeader {
+	var h MinSEHeader
+	if parseHeaderLazy(hs, parseMinSEHeader, []string{"min-se"}, &h) {
+		return &h
+	}
+	return nil
+}
+
 // NewHeader creates generic type of header
 func NewHeader(name, value string) Header {
 	return &genericHeader{
@@ -852,6 +873,92 @@ func (h *ExpiresHeader) Name() string { return "Expires" }
 func (h ExpiresHeader) Value() string { return strconv.Itoa(int(h)) }
 
 func (h *ExpiresHeader) headerClone() Header { return h }
+
+// SessionExpiresHeader is RFC 4028 Session-Expires header representation.
+// It carries the session interval in seconds and any parameters, notably
+// refresher=uac|uas. The refresher is kept as sent: electing or honoring a
+// refresher is negotiation policy, not parsing.
+type SessionExpiresHeader struct {
+	// Delta is the session interval in seconds.
+	Delta uint32
+	// Any parameters present in the header.
+	Params HeaderParams
+}
+
+func (h *SessionExpiresHeader) String() string {
+	var buffer strings.Builder
+	h.StringWrite(&buffer)
+	return buffer.String()
+}
+
+func (h *SessionExpiresHeader) StringWrite(buffer io.StringWriter) {
+	buffer.WriteString(h.Name())
+	buffer.WriteString(": ")
+	h.valueStringWrite(buffer)
+}
+
+func (h *SessionExpiresHeader) Name() string { return "Session-Expires" }
+
+func (h *SessionExpiresHeader) Value() string {
+	var buffer strings.Builder
+	h.valueStringWrite(&buffer)
+	return buffer.String()
+}
+
+func (h *SessionExpiresHeader) valueStringWrite(buffer io.StringWriter) {
+	buffer.WriteString(strconv.FormatUint(uint64(h.Delta), 10))
+
+	if (h.Params != nil) && (h.Params.Length() > 0) {
+		buffer.WriteString(";")
+		h.Params.ToStringWrite(';', buffer)
+	}
+}
+
+// Copy the header.
+func (h *SessionExpiresHeader) headerClone() Header {
+	return h.Clone()
+}
+
+func (h *SessionExpiresHeader) Clone() *SessionExpiresHeader {
+	var newSE *SessionExpiresHeader
+	if h == nil {
+		return newSE
+	}
+
+	newSE = &SessionExpiresHeader{
+		Delta: h.Delta,
+	}
+
+	if h.Params != nil {
+		newSE.Params = h.Params.Clone()
+	}
+
+	return newSE
+}
+
+// MinSEHeader is RFC 4028 Min-SE header representation. It is the minimum
+// session interval, in seconds, that the sender is willing to accept.
+type MinSEHeader uint32
+
+func (h *MinSEHeader) String() string {
+	return fmt.Sprintf("%s: %s", h.Name(), h.Value())
+}
+
+func (h *MinSEHeader) StringWrite(buffer io.StringWriter) {
+	buffer.WriteString(h.Name())
+	buffer.WriteString(": ")
+	buffer.WriteString(h.Value())
+}
+
+func (h *MinSEHeader) valueStringWrite(buffer io.StringWriter) {
+	buffer.WriteString(h.Value())
+}
+
+func (h *MinSEHeader) Name() string { return "Min-SE" }
+
+func (h MinSEHeader) Value() string { return strconv.FormatUint(uint64(h), 10) }
+
+func (h *MinSEHeader) headerClone() Header { return h }
 
 // ContentLengthHeader is Content-Length header representation
 type ContentLengthHeader uint32

--- a/sip/parse_header.go
+++ b/sip/parse_header.go
@@ -138,6 +138,45 @@ func parseMaxForwardsHeader(headerText string, maxfwd *MaxForwardsHeader) error 
 	return err
 }
 
+// parseSessionExpiresHeader parses SessionExpires header. Value is a delta
+// seconds integer followed by optional ';' separated params, notably
+// refresher=uac|uas. Params are kept as sent. The Min-SE floor and electing a
+// refresher are negotiation policy for the caller, not parsing.
+func parseSessionExpiresHeader(headerText string, h *SessionExpiresHeader) error {
+	deltaText := headerText
+	paramsText := ""
+	if ind := strings.IndexByte(headerText, ';'); ind >= 0 {
+		deltaText = headerText[:ind]
+		paramsText = headerText[ind+1:]
+	}
+
+	delta, err := strconv.ParseUint(strings.TrimSpace(deltaText), 10, 32)
+	if err != nil {
+		return fmt.Errorf("session-expires delta: %w", err)
+	}
+	h.Delta = uint32(delta)
+
+	if strings.TrimSpace(paramsText) == "" {
+		return nil
+	}
+
+	h.Params = NewParams()
+	if _, err := UnmarshalHeaderParams(paramsText, ';', 0, &h.Params); err != nil {
+		return fmt.Errorf("session-expires params: %w", err)
+	}
+	return nil
+}
+
+// parseMinSEHeader parses MinSE header. Value is a bare delta seconds integer.
+func parseMinSEHeader(headerText string, h *MinSEHeader) error {
+	delta, err := strconv.ParseUint(strings.TrimSpace(headerText), 10, 32)
+	if err != nil {
+		return fmt.Errorf("min-se delta: %w", err)
+	}
+	*h = MinSEHeader(delta)
+	return nil
+}
+
 func headerParserCSeq(headerName []byte, headerText string) (headers Header, err error) {
 	var cseq CSeqHeader
 	return &cseq, parseCSeqHeader(headerText, &cseq)

--- a/sip/session_timers_test.go
+++ b/sip/session_timers_test.go
@@ -1,0 +1,245 @@
+package sip
+
+import "testing"
+
+// headersWith builds headers carrying a single generic header, the same way an
+// inbound message exposes an unregistered header before any lazy accessor runs.
+// When present is false the header is absent, modelling a peer that offers no
+// session timers.
+func headersWith(present bool, name, value string) *headers {
+	hs := &headers{}
+	if present {
+		hs.AppendHeader(NewHeader(name, value))
+	}
+	return hs
+}
+
+func TestSessionExpiresParse(t *testing.T) {
+	tests := []struct {
+		name       string
+		present    bool
+		header     string
+		raw        string
+		wantNil    bool
+		wantDelta  uint32
+		wantParams map[string]string // nil => expect no params
+	}{
+		{
+			name:       "delta and refresher uas",
+			present:    true,
+			raw:        "1800;refresher=uas",
+			wantDelta:  1800,
+			wantParams: map[string]string{"refresher": "uas"},
+		},
+		{
+			name:       "delta and refresher uac kept as sent",
+			present:    true,
+			raw:        "1800;refresher=uac",
+			wantDelta:  1800,
+			wantParams: map[string]string{"refresher": "uac"},
+		},
+		{
+			name:      "delta only",
+			present:   true,
+			raw:       "1800",
+			wantDelta: 1800,
+		},
+		{
+			// Compact form of Session-Expires is "x" per RFC 4028.
+			name:       "compact form x",
+			present:    true,
+			header:     "x",
+			raw:        "1800;refresher=uas",
+			wantDelta:  1800,
+			wantParams: map[string]string{"refresher": "uas"},
+		},
+		{
+			// Zero parses as delta 0. Enforcing the Min-SE floor is policy for
+			// the caller, not a parse error.
+			name:      "zero delta parses",
+			present:   true,
+			raw:       "0",
+			wantDelta: 0,
+		},
+		{
+			// Unknown params are kept next to the refresher. Parsing does not
+			// elect or filter.
+			name:       "extra param kept",
+			present:    true,
+			raw:        "1800;refresher=uas;foo=bar",
+			wantDelta:  1800,
+			wantParams: map[string]string{"refresher": "uas", "foo": "bar"},
+		},
+		{
+			name:      "upper bound uint32 max",
+			present:   true,
+			raw:       "4294967295",
+			wantDelta: 4294967295,
+		},
+		{
+			name:    "non numeric delta rejected",
+			present: true,
+			raw:     "uas",
+			wantNil: true,
+		},
+		{
+			name:    "empty value rejected",
+			present: true,
+			raw:     "",
+			wantNil: true,
+		},
+		{
+			name:    "overflow uint32 rejected",
+			present: true,
+			raw:     "4294967296",
+			wantNil: true,
+		},
+		{
+			name:    "header absent returns nil",
+			present: false,
+			wantNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			header := tc.header
+			if header == "" {
+				header = "Session-Expires"
+			}
+
+			hs := headersWith(tc.present, header, tc.raw)
+			got := hs.SessionExpires()
+
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("SessionExpires() = %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("SessionExpires() = nil, want Delta=%d", tc.wantDelta)
+			}
+			if got.Delta != tc.wantDelta {
+				t.Fatalf("Delta = %d, want %d", got.Delta, tc.wantDelta)
+			}
+			assertParams(t, got.Params, tc.wantParams)
+		})
+	}
+}
+
+func TestMinSEParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		present bool
+		raw     string
+		wantNil bool
+		want    uint32
+	}{
+		{name: "valid", present: true, raw: "90", want: 90},
+		{name: "upper bound uint32 max", present: true, raw: "4294967295", want: 4294967295},
+		{name: "overflow uint32 rejected", present: true, raw: "4294967296", wantNil: true},
+		{name: "non numeric rejected", present: true, raw: "abc", wantNil: true},
+		{name: "empty rejected", present: true, raw: "", wantNil: true},
+		{name: "header absent returns nil", present: false, wantNil: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hs := headersWith(tc.present, "Min-SE", tc.raw)
+			got := hs.MinSE()
+
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("MinSE() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("MinSE() = nil, want %d", tc.want)
+			}
+			if uint32(*got) != tc.want {
+				t.Fatalf("MinSE() = %d, want %d", uint32(*got), tc.want)
+			}
+		})
+	}
+}
+
+// params builds HeaderParams from ordered key/value pairs.
+func params(kv ...string) HeaderParams {
+	p := NewParams()
+	for i := 0; i < len(kv); i += 2 {
+		p.Add(kv[i], kv[i+1])
+	}
+	return p
+}
+
+func TestSessionExpiresStringWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		h    SessionExpiresHeader
+		want string
+	}{
+		{
+			name: "delta only",
+			h:    SessionExpiresHeader{Delta: 1800},
+			want: "Session-Expires: 1800",
+		},
+		{
+			name: "with refresher",
+			h:    SessionExpiresHeader{Delta: 1800, Params: params("refresher", "uas")},
+			want: "Session-Expires: 1800;refresher=uas",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.h.String(); got != tc.want {
+				t.Fatalf("String() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMinSEStringWrite(t *testing.T) {
+	h := MinSEHeader(90)
+	if got, want := h.String(), "Min-SE: 90"; got != want {
+		t.Fatalf("String() = %q, want %q", got, want)
+	}
+}
+
+// TestSessionExpiresClone checks the clone does not share the params backing
+// array with the original.
+func TestSessionExpiresClone(t *testing.T) {
+	h := &SessionExpiresHeader{Delta: 1800, Params: params("refresher", "uas")}
+
+	clone := h.Clone()
+	clone.Params.Add("refresher", "uac")
+	clone.Delta = 90
+
+	if got, ok := h.Params.Get("refresher"); !ok || got != "uas" {
+		t.Fatalf("original refresher = %q (ok=%v), want %q", got, ok, "uas")
+	}
+	if h.Delta != 1800 {
+		t.Fatalf("original Delta = %d, want 1800", h.Delta)
+	}
+}
+
+// assertParams checks the parsed params match want exactly. A nil want means no
+// params at all.
+func assertParams(t *testing.T, got HeaderParams, want map[string]string) {
+	t.Helper()
+	if want == nil {
+		if got.Length() != 0 {
+			t.Fatalf("params = %v, want none", got)
+		}
+		return
+	}
+	for k, v := range want {
+		gv, ok := got.Get(k)
+		if !ok || gv != v {
+			t.Fatalf("param %q = %q (ok=%v), want %q", k, gv, ok, v)
+		}
+	}
+	if got.Length() != len(want) {
+		t.Fatalf("params length = %d, want %d (%v)", got.Length(), len(want), got)
+	}
+}


### PR DESCRIPTION
Fixes #334

Adds `SessionExpiresHeader` (uint32 delta-seconds plus optional `HeaderParams`) and `MinSEHeader` (uint32 delta). Both implement `Header` — `Name`, `Value`, `String`, `StringWrite`, `headerClone` — and `SessionExpiresHeader` also gets a typed `Clone`.
