### PR TITLE
transport: option to set the WS and WSS handshake path

### DIFF
--- a/sip/transport_layer.go
+++ b/sip/transport_layer.go
@@ -45,6 +45,10 @@ type TransportLayer struct {
 	// dnsPreferSRV does always SRV lookup first
 	dnsPreferSRV bool
 	dnsPreferIP  int // 0 - no preference , 1 -ip4, 2 - ip6
+
+	// wsDialPath is the handshake path for the default WS and WSS transports.
+	// Empty keeps the "/" that the URI scheme implies.
+	wsDialPath string
 }
 
 type TransportLayerOption func(l *TransportLayer)
@@ -60,6 +64,18 @@ func WithTransportLayerLogger(logger *slog.Logger) TransportLayerOption {
 func WithTransportLayerConnectionReuse(f bool) TransportLayerOption {
 	return func(l *TransportLayer) {
 		l.connectionReuse = f
+	}
+}
+
+// WithTransportLayerWSDialPath sets the handshake path used when dialing WS and
+// WSS, for this transport layer only. Most SIP over WebSocket servers expect
+// "/ws", while the dialer otherwise requests "/".
+//
+// It is ignored for a transport supplied through WithTransportLayerTransports,
+// which carries its own DialURI.
+func WithTransportLayerWSDialPath(path string) TransportLayerOption {
+	return func(l *TransportLayer) {
+		l.wsDialPath = path
 	}
 }
 
@@ -153,6 +169,7 @@ func NewTransportLayer(
 		},
 		WS: &TransportWS{
 			log:        l.log.With("caller", "Transport<WS>"),
+			DialURI:    func(host string) string { return "ws://" + host + l.wsDialPath },
 			readFilter: l.readFilter,
 		},
 		// TODO. Using default dial tls, but it needs to configurable via client
@@ -160,7 +177,7 @@ func NewTransportLayer(
 			TransportWS: &TransportWS{
 				log:             l.log.With("caller", "Transport<WSS>"),
 				connectionReuse: l.connectionReuse,
-				DialURI:         func(host string) string { return "wss://" + host },
+				DialURI:         func(host string) string { return "wss://" + host + l.wsDialPath },
 				readFilter:      l.readFilter,
 			},
 		},

--- a/sip/transport_wss.go
+++ b/sip/transport_wss.go
@@ -16,6 +16,10 @@ type TransportWSS struct {
 }
 
 func (t *TransportWSS) init(par *Parser, dialTLSConf *tls.Config) {
+	// Set before TransportWS.init, which otherwise defaults this to the ws:// scheme.
+	if t.DialURI == nil {
+		t.DialURI = func(addr string) string { return "wss://" + addr }
+	}
 	t.TransportWS.init(par)
 	t.TransportWS.transport = "WSS"
 	t.dialer.TLSConfig = dialTLSConf
@@ -91,7 +95,7 @@ func (t *TransportWSS) CreateConnection(ctx context.Context, laddr Addr, raddr A
 		log.Debug("Setuping TLS connection", "hostname", hostname)
 		tlsConn := t.dialer.TLSClient(conn, hostname)
 
-		u, err := url.ParseRequestURI("wss://" + addr)
+		u, err := url.ParseRequestURI(t.DialURI(addr))
 		if err != nil {
 			return nil, fmt.Errorf("parse request wss uri failed: %w", err)
 		}

--- a/sip/transport_wss_test.go
+++ b/sip/transport_wss_test.go
@@ -2,8 +2,28 @@ package sip
 
 import (
 	"crypto/tls"
+	"net"
 	"testing"
 )
+
+func TestTransportLayerWSDialPath(t *testing.T) {
+	l := NewTransportLayer(net.DefaultResolver, NewParser(), nil, WithTransportLayerWSDialPath("/ws"))
+
+	if got := l.wss.DialURI("localhost:443"); got != "wss://localhost:443/ws" {
+		t.Fatalf("wss: expected wss://localhost:443/ws, got %q", got)
+	}
+	if got := l.ws.DialURI("localhost:80"); got != "ws://localhost:80/ws" {
+		t.Fatalf("ws: expected ws://localhost:80/ws, got %q", got)
+	}
+}
+
+func TestTransportLayerWSDialPathUnsetKeepsRoot(t *testing.T) {
+	l := NewTransportLayer(net.DefaultResolver, NewParser(), nil)
+
+	if got := l.wss.DialURI("localhost:443"); got != "wss://localhost:443" {
+		t.Fatalf("expected wss://localhost:443, got %q", got)
+	}
+}
 
 func TestTransportWSSDialURI(t *testing.T) {
 	t.Run("defaults to wss scheme", func(t *testing.T) {

--- a/sip/transport_wss_test.go
+++ b/sip/transport_wss_test.go
@@ -1,0 +1,30 @@
+package sip
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestTransportWSSDialURI(t *testing.T) {
+	t.Run("defaults to wss scheme", func(t *testing.T) {
+		tran := &TransportWSS{TransportWS: &TransportWS{}}
+		tran.init(NewParser(), &tls.Config{})
+
+		got := tran.DialURI("localhost:443")
+		if got != "wss://localhost:443" {
+			t.Fatalf("expected wss://localhost:443, got %q", got)
+		}
+	})
+
+	t.Run("caller DialURI is kept", func(t *testing.T) {
+		tran := &TransportWSS{TransportWS: &TransportWS{
+			DialURI: func(host string) string { return "wss://" + host + "/ws" },
+		}}
+		tran.init(NewParser(), &tls.Config{})
+
+		got := tran.DialURI("localhost:443")
+		if got != "wss://localhost:443/ws" {
+			t.Fatalf("expected wss://localhost:443/ws, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #338

Stacked on #320, which makes WSS honour `DialURI` at all. Please take that first — the diff here is only the option on top.

Most SIP over WebSocket servers expect `/ws` while the dialer requests `/`. `DialURI` already expresses this, but nothing could set it short of supplying a whole transport through `WithTransportLayerTransports` — which means hand-constructing `TransportWS`/`TransportWSS` just to change a path.

`WithTransportLayerWSDialPath` appends a handshake path to the default WS and WSS `DialURI` built in `NewTransportLayer`. Per transport layer rather than a package global, so two user agents in one process can dial different paths. Ignored for a transport supplied through `WithTransportLayerTransports`, since that one carries its own `DialURI`.

One exported option, no behaviour change when unset.