### PR TITLE
parser: bound datagram body allocation by message size

### DIFF
--- a/sip/parser.go
+++ b/sip/parser.go
@@ -275,6 +275,15 @@ func (p *Parser) Parse(data []byte, stream bool) (Message, int, error) {
 	if bodySize == 0 {
 		return msg, total, nil
 	}
+	// Content-Length is attacker-controlled and independent of how many bytes
+	// actually arrived: a small datagram can declare a body of up to 4 GB and
+	// drive the make below to allocate it before the copy can reject it. The
+	// stream parser already bounds this against MaxMessageLength; the datagram
+	// path must too. Subtracting keeps the check from overflowing int, and total
+	// never exceeds MaxMessageLength because the whole datagram was bounded above.
+	if bodySize > p.MaxMessageLength-total {
+		return msg, total, ErrMessageTooLarge
+	}
 	body := make([]byte, bodySize)
 	n := copy(body, data)
 	total += n

--- a/sip/parser_test.go
+++ b/sip/parser_test.go
@@ -352,6 +352,38 @@ func TestParseBadMessages(t *testing.T) {
 
 }
 
+// TestParseDatagramBodyBound checks that the non-stream (datagram) parse path
+// rejects a message whose declared Content-Length exceeds the message-size limit
+// before it allocates a body. Without the bound, a small unauthenticated datagram
+// declaring a multi-gigabyte Content-Length drives make([]byte, bodySize) to
+// commit that much memory — a pre-auth amplification DoS on the UDP and WebSocket
+// ingress paths, both of which parse through ParseSIP -> Parse(stream=false).
+func TestParseDatagramBodyBound(t *testing.T) {
+	parser := NewParser()
+
+	rawMsg := []string{
+		"INVITE sip:victim@example.com SIP/2.0",
+		"Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK1",
+		"From: <sip:attacker@example.com>;tag=1",
+		"To: <sip:victim@example.com>",
+		"Call-ID: body-bound@10.0.0.1",
+		"CSeq: 1 INVITE",
+		// Well over the default MaxMessageLength (65535). The real attack declares
+		// the uint32 maximum (~4.29 GB); the same guard bounds both. A modest value
+		// keeps this test from allocating gigabytes if the guard is ever reverted.
+		"Content-Length: 1000000",
+		"",
+		"x",
+	}
+	msgstr := strings.Join(rawMsg, "\r\n")
+
+	_, _, err := parser.Parse([]byte(msgstr), false)
+	require.ErrorIs(t, err, ErrMessageTooLarge)
+
+	_, err = parser.ParseSIP([]byte(msgstr))
+	require.ErrorIs(t, err, ErrMessageTooLarge)
+}
+
 func TestParseRequest(t *testing.T) {
 	branch := GenerateBranch()
 	callid := fmt.Sprintf("gotest-%d", time.Now().UnixNano())


### PR DESCRIPTION
Fixes #342

One check, between the `bodySize == 0` early return and the `make`:

```go
if bodySize > p.MaxMessageLength-total {
    return msg, total, ErrMessageTooLarge
}
```
