### PR TITLE
fix(transaction): keep client responses in order of arrival

### DIFF
--- a/sip/transaction_client_tx.go
+++ b/sip/transaction_client_tx.go
@@ -8,7 +8,11 @@ import (
 
 type ClientTx struct {
 	baseTx
-	responses    chan *Response
+	responses chan *Response
+	// receiveOrder is the tail of the chain of tickets handed out by
+	// receiveTicket. It keeps responses of this transaction reaching the
+	// FSM in the order they were received from the transport.
+	receiveOrder chan struct{}
 	timer_a_time time.Duration // Current duration of timer A.
 	timer_a      *time.Timer
 	timer_b      *time.Timer
@@ -29,8 +33,36 @@ func NewClientTx(key string, origin *Request, conn Connection, logger *slog.Logg
 	tx.done = make(chan struct{})
 	tx.log = logger
 
+	// First ticket has nothing to wait for.
+	first := make(chan struct{})
+	close(first)
+	tx.receiveOrder = first
+
 	tx.origin = origin // TODO:Due to subsequent request like ack we need to use clone to avoid races
 	return tx
+}
+
+// receiveTicket hands out a ticket that keeps responses reaching the FSM in
+// the order they arrived from the transport.
+//
+// The transport layer delivers every message in its own goroutine, so the
+// goroutines carrying two responses of the same transaction race for fsmMu
+// and can enter the FSM in reverse order. A 1xx entering after a 2xx is then
+// dropped by the "Accepted" state as a stray response (RFC 6026), even
+// though it was received before the 2xx.
+//
+// Callers must take the ticket while still in the receiving goroutine, wait
+// for the returned channel before calling Receive, and close the ticket
+// afterwards.
+func (tx *ClientTx) receiveTicket() (wait <-chan struct{}, ticket chan struct{}) {
+	next := make(chan struct{})
+
+	tx.mu.Lock()
+	prev := tx.receiveOrder
+	tx.receiveOrder = next
+	tx.mu.Unlock()
+
+	return prev, next
 }
 
 func (tx *ClientTx) Init() error {

--- a/sip/transaction_layer.go
+++ b/sip/transaction_layer.go
@@ -139,7 +139,10 @@ func (txl *TransactionLayer) handleMessage(msg Message) {
 	case *Request:
 		go txl.handleRequestBackground(msg)
 	case *Response:
-		go txl.handleResponseBackground(msg)
+		// Matching is done here, in the receiving goroutine, so that
+		// responses of one transaction keep their arrival order.
+		// Passing them to the FSM still happens in a separate goroutine.
+		txl.handleResponseOrdered(msg)
 	default:
 		txl.log.Error("unsupported message, skip it")
 	}
@@ -275,28 +278,47 @@ func (txl *TransactionLayer) serverTxCreate(req *Request, key string) (*ServerTx
 	return tx, nil
 }
 
-func (txl *TransactionLayer) handleResponseBackground(res *Response) {
-	if err := txl.handleResponse(res); err != nil {
-		txl.log.Error("Client tx failed to handle response", "error", err)
-	}
-}
-
-func (txl *TransactionLayer) handleResponse(res *Response) error {
+// handleResponseOrdered matches a response to its client transaction and
+// passes it to the transaction FSM without losing the order of arrival.
+//
+// Matching runs in the calling (transport receiving) goroutine, which is
+// what makes the order well defined; the FSM is still spun in a separate
+// goroutine, because fsmPassUp blocks until the TU consumes the response and
+// blocking the receiving goroutine on that would stall the connection.
+//
+// Without ordering, two responses received back to back race for fsmMu. When
+// the 2xx wins, the client INVITE transaction moves to "Accepted" and the 1xx
+// that arrived first is then discarded by that state as a stray response
+// (RFC 6026 7.2), so the TU never sees it. In practice this loses ringing and
+// early media announcements from user agents that answer immediately.
+func (txl *TransactionLayer) handleResponseOrdered(res *Response) {
 	key, err := ClientTxKeyMake(res)
 	if err != nil {
-		return fmt.Errorf("make key failed: %w", err)
+		txl.log.Error("Client tx failed to handle response", "error", fmt.Errorf("make key failed: %w", err))
+		return
 	}
 
 	tx, exists := txl.getClientTx(key)
 	if !exists {
 		// RFC 3261 - 17.1.1.2.
 		// Not matched responses should be passed directly to the UA
-		txl.unRespHandler(res)
-		return nil
+		go txl.unRespHandler(res)
+		return
 	}
 
-	tx.Receive(res)
-	return nil
+	wait, ticket := tx.receiveTicket()
+	go func() {
+		// The ticket is released even when the transaction is already gone,
+		// so that responses queued behind this one are not stuck.
+		defer close(ticket)
+
+		select {
+		case <-wait:
+		case <-tx.done:
+			return
+		}
+		tx.Receive(res)
+	}()
 }
 
 func (txl *TransactionLayer) Request(ctx context.Context, req *Request) (*ClientTx, error) {

--- a/sip/transaction_layer_response_order_test.go
+++ b/sip/transaction_layer_response_order_test.go
@@ -1,0 +1,93 @@
+package sip
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/emiago/sipgo/fakes"
+	"github.com/stretchr/testify/require"
+)
+
+// Responses received back to back must reach the TU in the order they were
+// received.
+//
+// The transport layer delivers every message in its own goroutine. Without
+// ordering, the goroutines carrying 180 and 200 of the same transaction race
+// for fsmMu; when the 200 wins, the transaction moves to "Accepted" and the
+// 180 is then discarded by that state as a stray response (RFC 6026 7.2).
+// The TU never sees the 180, which in a call means losing ringing and any
+// early media announcement carried by it.
+//
+// Repeated, because the loss depends on goroutine scheduling: on the code
+// before this fix the 180 was lost in nearly every iteration.
+func TestTransactionLayerResponseOrder(t *testing.T) {
+	const iterations = 20
+
+	for i := 0; i < iterations; i++ {
+		txl, tx, req := testResponseOrderSetup(t)
+
+		ringing := NewResponseFromRequest(req, StatusRinging, "Ringing", nil)
+		ok := NewResponseFromRequest(req, StatusOK, "OK", nil)
+
+		// Same as the transport layer does: both responses handed over by
+		// the receiving goroutine, one after another.
+		txl.handleMessage(ringing)
+		txl.handleMessage(ok)
+
+		first := testReceiveResponse(t, tx)
+		require.Equal(t, StatusRinging, first.StatusCode, "provisional response lost or reordered")
+
+		second := testReceiveResponse(t, tx)
+		require.Equal(t, StatusOK, second.StatusCode)
+
+		tx.Terminate()
+	}
+}
+
+func testResponseOrderSetup(t *testing.T) (*TransactionLayer, *ClientTx, *Request) {
+	t.Helper()
+
+	req, _, _ := testCreateInvite(t, "sip:127.0.0.99:5060", "udp", "127.0.0.2:5060")
+	req.raddr = Addr{IP: net.ParseIP("127.0.0.99"), Port: 5060}
+
+	conn := &UDPConnection{
+		PacketConn: &fakes.UDPConn{
+			Reader:  bytes.NewBuffer([]byte{}),
+			Writers: map[string]io.Writer{"127.0.0.99:5060": bytes.NewBuffer([]byte{})},
+		},
+	}
+
+	key, err := ClientTxKeyMake(req)
+	require.NoError(t, err)
+
+	tx := NewClientTx(key, req, conn, slog.Default())
+	require.NoError(t, tx.Init())
+
+	txl := &TransactionLayer{
+		clientTransactions: newTransactionStore[*ClientTx](),
+		serverTransactions: newTransactionStore[*ServerTx](),
+		reqHandler:         defaultRequestHandler,
+		unRespHandler:      defaultUnhandledRespHandler,
+		log:                DefaultLogger(),
+	}
+	txl.clientTransactions.put(key, tx)
+	t.Cleanup(func() { tx.Terminate() })
+
+	return txl, tx, req
+}
+
+func testReceiveResponse(t *testing.T, tx *ClientTx) *Response {
+	t.Helper()
+
+	select {
+	case res := <-tx.Responses():
+		return res
+	case <-time.After(2 * time.Second):
+		t.Fatal("no response passed up to TU")
+	}
+	return nil
+}


### PR DESCRIPTION
### Problem

A UAC loses provisional responses whenever the peer answers immediately.
With a UAS that sends `180 Ringing` and `200 OK` back to back, the `180`
never reaches the TU in 16 to 20 runs out of 20 — `WaitAnswer`'s
`OnResponse` is called only for the `200`.

In a call this is the lost ringing indication and, when the provisional
carries SDP, the lost early media announcement: the caller hears silence
where the network should be heard. It shows up with auto answering
endpoints, intercoms and gateways that emit `100` and `18x` in one burst.

### Root cause

`TransactionLayer.handleMessage` hands every message to its own goroutine:

    case *Response:
        go txl.handleResponseBackground(msg)

The order of arrival is therefore lost right there. Both goroutines then
race for `fsmMu` in `spinFsmWithResponse`. When the `200` wins, the client
INVITE transaction moves to `inviteStateAccepted`; the `180` that was
received first arrives afterwards, hits the `default` branch of that state
and is silently dropped as a stray response (RFC 6026 7.2 — correct
behaviour for a response that really is stray, but this one is not).

The shared `tx.fsmResp` field makes it worse: the late `180` overwrites it
while the transaction is already in `Accepted`. The `TODO v2` at the top of
`transaction_client_tx_fsm.go` — passing the response through the FSM as
context instead of a shared field — points at the same design issue.

### Fix

Match the response to its transaction in the receiving goroutine, where the
order is still well defined, and let the transaction hand out a ticket that
keeps per-transaction delivery in that order. Spinning the FSM stays in a
separate goroutine, because `fsmPassUp` blocks until the TU consumes the
response and blocking the transport receive loop on that would stall the
connection — which is what the comment in `handleMessage` warns about.

`handleResponse`/`handleResponseBackground` are folded into the new
`handleResponseOrdered`; no exported API changes.

### Test

`TestTransactionLayerResponseOrder` hands two responses to `handleMessage`
one after another, exactly as the transport layer does, and requires the
TU to see `180` before `200`. It fails on current `master` and passes with
this change. It repeats 20 times, because a single iteration would be a
coin flip rather than a deterministic failure.

### Verification

- `go test ./...` passes (`testdata/generate_certs.sh` is needed for the
  root package tests).
- With `TEST_INTEGRATION=1 -race`, `TestTransactionLayerClientTx` and
  `TestTransportLayerClientConnectionReuse` fail with data races both with
  and without this change — pre-existing, not touched here.
- Checked against a real B2BUA test suite (two UAs in one process, media
  and routing stubbed): the provisional loss goes from 16–20 out of 20 to
  0 out of 20, and the suite stays green under `-race`.