### PR TITLE
fix(dialog): ACK and CANCEL keep the CSeq of the request they refer to

### DIFF
--- a/dialog.go
+++ b/dialog.go
@@ -33,8 +33,13 @@ type Dialog struct {
 	InviteRequest *sip.Request
 
 	// lastCSeqNo is set for every request within dialog except ACK CANCEL
-	lastCSeqNo   atomic.Uint32
-	remoteCSeqNo atomic.Uint32
+	lastCSeqNo atomic.Uint32
+	// lastInviteCSeqNo is the sequence number of the last INVITE sent within
+	// the dialog. ACK and CANCEL refer to a request instead of starting one,
+	// so this is the number they carry when the caller did not set a CSeq
+	// header of their own.
+	lastInviteCSeqNo atomic.Uint32
+	remoteCSeqNo     atomic.Uint32
 
 	// InviteResponse is last response received or sent. It is not thread safe!
 	// Use it only as read only and do not change values
@@ -53,10 +58,12 @@ func (d *Dialog) Init() {
 	d.ctx, d.cancel = context.WithCancelCause(context.Background())
 	d.state = atomic.Int32{}
 	d.lastCSeqNo = atomic.Uint32{}
+	d.lastInviteCSeqNo = atomic.Uint32{}
 
 	// We may have sequence number initialized
 	if cseq := d.InviteRequest.CSeq(); cseq != nil {
 		d.lastCSeqNo.Store(cseq.SeqNo)
+		d.lastInviteCSeqNo.Store(cseq.SeqNo)
 		d.remoteCSeqNo.Store(cseq.SeqNo)
 	}
 	d.onStatePointer = atomic.Pointer[DialogStateFn]{}

--- a/dialog_client.go
+++ b/dialog_client.go
@@ -115,6 +115,9 @@ func (s *DialogClientSession) buildReq(req *sip.Request) {
 	}
 
 	cseq := req.CSeq()
+	// Whether the caller chose the sequence number matters for ACK and CANCEL
+	// below: only then does the header identify the request they refer to.
+	cseqFromCaller := cseq != nil
 	if cseq == nil {
 		cseq = &sip.CSeqHeader{
 			SeqNo:      s.InviteRequest.CSeq().SeqNo,
@@ -126,13 +129,41 @@ func (s *DialogClientSession) buildReq(req *sip.Request) {
 		req.PrependHeader(mustHaveHeaders...)
 	}
 
-	// For safety make sure we are starting with our last dialog cseq num
-	cseq.SeqNo = s.lastCSeqNo.Load()
-
-	if !req.IsAck() && !req.IsCancel() {
+	// ACK and CANCEL refer to an earlier request instead of starting a new
+	// transaction, so they keep its sequence number and do not consume one of
+	// their own:
+	//
+	//	https://datatracker.ietf.org/doc/html/rfc3261#section-13.2.2.4
+	//	The sequence number of the CSeq header field MUST be the same as the
+	//	INVITE being acknowledged, but the CSeq method MUST be ACK.
+	//
+	//	https://datatracker.ietf.org/doc/html/rfc3261#section-9.1
+	//	The CSeq header field in the CANCEL request MUST have the same value as
+	//	the CSeq field in the request being cancelled.
+	//
+	// Everything else takes the next number in the dialog.
+	switch {
+	case !req.IsAck() && !req.IsCancel():
 		// Do cseq increment within dialog
-		cseq.SeqNo++
+		cseq.SeqNo = s.lastCSeqNo.Load() + 1
+		s.lastCSeqNo.Store(cseq.SeqNo)
+		if req.IsInvite() {
+			s.lastInviteCSeqNo.Store(cseq.SeqNo)
+		}
+	case cseqFromCaller:
+		// The caller said which request is being acknowledged or cancelled.
+	default:
+		// Otherwise it is the last INVITE sent within the dialog: for a bare
+		// ACK built by the caller that is the re-INVITE just answered, and for
+		// the first one the initial INVITE. The dialog counter is not usable
+		// here, as a PRACK or an UPDATE between the INVITE and its final
+		// response has moved it on.
+		if seq := s.lastInviteCSeqNo.Load(); seq > 0 {
+			cseq.SeqNo = seq
+		}
 	}
+	// The counter is left alone by ACK and CANCEL, so that the next request
+	// stays above the PRACK instead of colliding with it.
 
 	// Check record route header
 	if s.InviteResponse != nil {
@@ -161,7 +192,6 @@ func (s *DialogClientSession) buildReq(req *sip.Request) {
 		req.AppendHeader(sip.HeaderClone(&s.UA.ContactHDR))
 	}
 
-	s.lastCSeqNo.Store(cseq.SeqNo)
 	// Make sure transport matches original invite
 	req.SetTransport(s.InviteRequest.Transport())
 }
@@ -210,7 +240,10 @@ func (d *DialogClientSession) Invite(ctx context.Context, options ...ClientReque
 	}()
 
 	if err == nil {
+		// The initial INVITE is built by the client, not by buildReq, so both
+		// counters are set here.
 		d.lastCSeqNo.Store(inviteReq.CSeq().SeqNo)
+		d.lastInviteCSeqNo.Store(inviteReq.CSeq().SeqNo)
 	}
 
 	return err

--- a/dialog_client_cseq_test.go
+++ b/dialog_client_cseq_test.go
@@ -1,0 +1,136 @@
+package sipgo
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/emiago/sipgo/sip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A PRACK or an UPDATE sent between the INVITE and its final response moves the
+// dialog sequence number on. The ACK for the 2xx must still carry the sequence
+// number of the INVITE it acknowledges, and it must not consume a number of its
+// own, so that the next in dialog request stays above the PRACK.
+//
+// https://datatracker.ietf.org/doc/html/rfc3261#section-13.2.2.4
+func TestDialogClientAckCSeqIsInviteCSeq(t *testing.T) {
+	client := testClient(t, func(req *sip.Request) *sip.Response {
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
+	})
+
+	invite := sip.NewRequest(sip.INVITE, sip.Uri{User: "test", Host: "uas.example.com"})
+	invite.AppendHeader(sip.NewHeader("Contact", "<sip:uac@uac.example.com>"))
+	require.NoError(t, clientRequestBuildReq(client, invite))
+	inviteCSeq := invite.CSeq().SeqNo
+
+	res := sip.NewResponseFromRequest(invite, 200, "OK", nil)
+	res.AppendHeader(sip.NewHeader("Contact", "<sip:uas@uas.example.com>"))
+
+	s := DialogClientSession{
+		UA:       &DialogUA{Client: client},
+		Dialog:   Dialog{InviteRequest: invite, InviteResponse: res},
+		inviteTx: sip.NewClientTx("test", invite, nil, slog.Default()),
+	}
+	s.Dialog.Init()
+
+	ctx := context.Background()
+
+	// Two reliable provisional responses acknowledged with PRACK. Each PRACK is
+	// a request of its own within the dialog and takes the next number.
+	for i := uint32(1); i <= 2; i++ {
+		prack := sip.NewRequest(sip.PRACK, res.Contact().Address)
+		_, err := s.TransactionRequest(ctx, prack)
+		require.NoError(t, err)
+		assert.Equal(t, inviteCSeq+i, prack.CSeq().SeqNo, "PRACK takes the next number in the dialog")
+	}
+
+	// The write itself has no transport in this test, only the request built for
+	// it is of interest.
+	ack := newAckRequestUAC(s.InviteRequest, s.InviteResponse, nil)
+	_ = s.WriteAck(ctx, ack)
+	assert.Equal(t, inviteCSeq, ack.CSeq().SeqNo, "ACK carries the CSeq of the INVITE it acknowledges")
+	assert.Equal(t, sip.ACK, ack.CSeq().MethodName)
+
+	// The ACK consumed no number of its own, so the next request continues above
+	// the last PRACK instead of colliding with it.
+	bye := newByeRequestUAC(s.InviteRequest, s.InviteResponse, nil)
+	_, err := s.TransactionRequest(ctx, bye)
+	require.NoError(t, err)
+	assert.Equal(t, inviteCSeq+3, bye.CSeq().SeqNo, "BYE continues above the last PRACK")
+}
+
+// An ACK for a re-INVITE cannot use the CSeq of the initial INVITE: the caller
+// knows which transaction is being acknowledged and sets the header itself.
+func TestDialogClientAckCSeqKeptWhenSet(t *testing.T) {
+	client := testClient(t, func(req *sip.Request) *sip.Response {
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
+	})
+
+	invite := sip.NewRequest(sip.INVITE, sip.Uri{User: "test", Host: "uas.example.com"})
+	invite.AppendHeader(sip.NewHeader("Contact", "<sip:uac@uac.example.com>"))
+	require.NoError(t, clientRequestBuildReq(client, invite))
+	inviteCSeq := invite.CSeq().SeqNo
+
+	res := sip.NewResponseFromRequest(invite, 200, "OK", nil)
+	res.AppendHeader(sip.NewHeader("Contact", "<sip:uas@uas.example.com>"))
+
+	s := DialogClientSession{
+		UA:       &DialogUA{Client: client},
+		Dialog:   Dialog{InviteRequest: invite, InviteResponse: res},
+		inviteTx: sip.NewClientTx("test", invite, nil, slog.Default()),
+	}
+	s.Dialog.Init()
+
+	ctx := context.Background()
+
+	reinvite := sip.NewRequest(sip.INVITE, res.Contact().Address)
+	_, err := s.TransactionRequest(ctx, reinvite)
+	require.NoError(t, err)
+	require.Equal(t, inviteCSeq+1, reinvite.CSeq().SeqNo)
+
+	ack := sip.NewRequest(sip.ACK, res.Contact().Address)
+	ack.AppendHeader(&sip.CSeqHeader{SeqNo: reinvite.CSeq().SeqNo, MethodName: sip.ACK})
+	_ = s.WriteAck(ctx, ack)
+	assert.Equal(t, reinvite.CSeq().SeqNo, ack.CSeq().SeqNo, "ACK for a re-INVITE keeps the CSeq set by the caller")
+}
+
+// An ACK for a re-INVITE built without a CSeq header must acknowledge that
+// re-INVITE, not the initial one: WriteAck does not ask the caller to set the
+// header, and the sequence number of the initial INVITE would leave the UAS
+// retransmitting its 2xx.
+func TestDialogClientAckCSeqReInviteWithoutHeader(t *testing.T) {
+	client := testClient(t, func(req *sip.Request) *sip.Response {
+		return sip.NewResponseFromRequest(req, 200, "OK", nil)
+	})
+
+	invite := sip.NewRequest(sip.INVITE, sip.Uri{User: "test", Host: "uas.example.com"})
+	invite.AppendHeader(sip.NewHeader("Contact", "<sip:uac@uac.example.com>"))
+	require.NoError(t, clientRequestBuildReq(client, invite))
+	inviteCSeq := invite.CSeq().SeqNo
+
+	res := sip.NewResponseFromRequest(invite, 200, "OK", nil)
+	res.AppendHeader(sip.NewHeader("Contact", "<sip:uas@uas.example.com>"))
+
+	s := DialogClientSession{
+		UA:       &DialogUA{Client: client},
+		Dialog:   Dialog{InviteRequest: invite, InviteResponse: res},
+		inviteTx: sip.NewClientTx("test", invite, nil, slog.Default()),
+	}
+	s.Dialog.Init()
+
+	ctx := context.Background()
+
+	reinvite := sip.NewRequest(sip.INVITE, res.Contact().Address)
+	_, err := s.TransactionRequest(ctx, reinvite)
+	require.NoError(t, err)
+	require.Equal(t, inviteCSeq+1, reinvite.CSeq().SeqNo)
+
+	ack := sip.NewRequest(sip.ACK, res.Contact().Address)
+	_ = s.WriteAck(ctx, ack)
+	assert.Equal(t, reinvite.CSeq().SeqNo, ack.CSeq().SeqNo,
+		"ACK without a CSeq header acknowledges the last INVITE sent")
+	assert.Equal(t, sip.ACK, ack.CSeq().MethodName)
+}


### PR DESCRIPTION
DialogClientSession.buildReq derives the CSeq of every request within the dialog from the dialog counter, ACK and CANCEL included. RFC 3261 requires the opposite: an ACK carries the sequence number of the INVITE it acknowledges (13.2.2.4) and a CANCEL the one of the request being cancelled (9.1), and neither consumes a number of its own.

The two values differ as soon as anything is sent between the INVITE and its final response. With reliable provisional responses that is the normal case: every PRACK moves the counter on, so the ACK for the 2xx leaves with the sequence number of the last PRACK. The UAS does not match it to the INVITE, keeps retransmitting the 2xx until the timer expires and then releases the call, which makes every call using 100rel fail to establish.

Take the number from the CSeq the caller set, or from the initial INVITE filled in above, and leave the dialog counter alone so that the next request stays above the PRACK instead of colliding with it. An ACK for a re-INVITE keeps working: the caller sets the CSeq of that re-INVITE and it is no longer overwritten.

The added tests fail on the code before this change and pass after it.