### PR TITLE
sip: parse a URN instead of reading its NSS as a port

### DIFF
--- a/sip/parse_uri.go
+++ b/sip/parse_uri.go
@@ -42,6 +42,21 @@ func uriStateScheme(uri *Uri, s string) (uriFSM, string, error) {
 	for i, c := range s {
 		if c == ':' {
 			uri.Scheme = ASCIIToLower(s[:i])
+
+			// A URN's namespace specific string is opaque (RFC 2141): it has
+			// no user, host or port, and the colons inside it separate
+			// namespaces rather than introducing a port. Handing
+			// "service:sos" on to the user and host states reads "sos" as a
+			// port and fails the whole URI, so a URN is taken verbatim and
+			// the FSM stops here.
+			if uri.Scheme == "urn" {
+				uri.Opaque = s[i+1:]
+				if uri.Opaque == "" {
+					return nil, "", fmt.Errorf("urn with no namespace specific string")
+				}
+				return nil, "", nil
+			}
+
 			return uriStateSlashes, s[i+1:], nil
 		}
 		// Check is c still ASCII

--- a/sip/parse_uri_test.go
+++ b/sip/parse_uri_test.go
@@ -134,6 +134,94 @@ func TestParseUri(t *testing.T) {
 
 }
 
+func TestParseUriURN(t *testing.T) {
+	// A URN's namespace specific string is opaque (RFC 2141), so it is kept
+	// whole rather than split into user, host and port.
+
+	t.Run("service urn", func(t *testing.T) {
+		// The emergency service URN of RFC 5031, which a UE puts in the
+		// Request-URI of an emergency INVITE.
+		uri := Uri{}
+		err := ParseUri("urn:service:sos", &uri)
+		require.NoError(t, err)
+
+		assert.Equal(t, "urn", uri.Scheme)
+		assert.Equal(t, "service:sos", uri.Opaque)
+		assert.Equal(t, "", uri.User)
+		assert.Equal(t, "", uri.Host)
+		assert.Equal(t, 0, uri.Port)
+		assert.Equal(t, "urn:service:sos", uri.String())
+	})
+
+	t.Run("sub service urn", func(t *testing.T) {
+		uri := Uri{}
+		err := ParseUri("urn:service:sos.police", &uri)
+		require.NoError(t, err)
+		assert.Equal(t, "service:sos.police", uri.Opaque)
+		assert.Equal(t, "urn:service:sos.police", uri.String())
+	})
+
+	t.Run("uuid urn", func(t *testing.T) {
+		// RFC 4122, as carried by a +sip.instance media feature tag.
+		uri := Uri{}
+		err := ParseUri("urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6", &uri)
+		require.NoError(t, err)
+		assert.Equal(t, "uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6", uri.Opaque)
+		assert.Equal(t, "urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6", uri.String())
+	})
+
+	t.Run("case insensitive scheme", func(t *testing.T) {
+		// Only the scheme is lowercased. The namespace specific string is
+		// opaque, so its case is preserved.
+		uri := Uri{}
+		err := ParseUri("URN:service:SOS", &uri)
+		require.NoError(t, err)
+		assert.Equal(t, "urn", uri.Scheme)
+		assert.Equal(t, "service:SOS", uri.Opaque)
+	})
+
+	t.Run("semicolon belongs to the namespace specific string", func(t *testing.T) {
+		// ";" is a legal NSS character (RFC 2141 <other>), and SIP
+		// uri-parameters are defined for SIP and SIPS URIs only (RFC 3261
+		// section 19.1.1) — a URN in a Request-URI is an absoluteURI and has
+		// none. So it stays inside the NSS rather than being split off, and
+		// the URI still round trips.
+		uri := Uri{}
+		err := ParseUri("urn:service:sos;lr", &uri)
+		require.NoError(t, err)
+
+		assert.Equal(t, "service:sos;lr", uri.Opaque)
+		assert.Equal(t, 0, uri.UriParams.Length())
+		assert.Equal(t, "urn:service:sos;lr", uri.String())
+	})
+
+	t.Run("params set by hand are still written", func(t *testing.T) {
+		// Parsing never puts them there, but an application constructing a
+		// URN by hand may, so the tail is written for it.
+		uri := Uri{Scheme: "urn", Opaque: "service:sos"}
+		uri.UriParams = NewParams()
+		uri.UriParams.Add("lr", "")
+		assert.Equal(t, "urn:service:sos;lr", uri.String())
+	})
+
+	t.Run("no namespace specific string", func(t *testing.T) {
+		uri := Uri{}
+		err := ParseUri("urn:", &uri)
+		require.Error(t, err)
+	})
+
+	t.Run("sip uri keeps opaque empty", func(t *testing.T) {
+		// Nothing that does not use a URN is affected.
+		uri := Uri{}
+		err := ParseUri("sip:alice@atlanta.com:5060", &uri)
+		require.NoError(t, err)
+		assert.Equal(t, "", uri.Opaque)
+		assert.Equal(t, "alice", uri.User)
+		assert.Equal(t, "atlanta.com", uri.Host)
+		assert.Equal(t, 5060, uri.Port)
+	})
+}
+
 func TestParseUriBad(t *testing.T) {
 	t.Run("double ports", func(t *testing.T) {
 		str := "sip:127.0.0.1:5060:5060;lr;transport=udp"

--- a/sip/parser_test.go
+++ b/sip/parser_test.go
@@ -430,6 +430,43 @@ func TestParseRequest(t *testing.T) {
 	assert.Equal(t, msg.String(), msgstr)
 }
 
+func TestParseRequestURN(t *testing.T) {
+	// RFC 3261 section 7.1 allows any absoluteURI as a Request-URI, and RFC
+	// 5031 defines the service URN a UE puts there for an emergency call. The
+	// failure this covers is not a wrong field but a lost message: reading
+	// "sos" as a port fails parseRequestLine, so the whole request is
+	// rejected and no handler ever runs.
+	rawMsg := []string{
+		"INVITE urn:service:sos SIP/2.0",
+		"Via: SIP/2.0/UDP 127.0.0.2:5060;branch=z9hG4bK-urn",
+		"From: \"Alice\" <sip:alice@127.0.0.2:5060>;tag=1928301774",
+		"To: <urn:service:sos>",
+		"Call-ID: gotest-urn",
+		"CSeq: 1 INVITE",
+		"Content-Length: 0",
+		"",
+		"",
+	}
+	msgstr := strings.Join(rawMsg, "\r\n")
+
+	parser := NewParser()
+	msg, err := parser.ParseSIP([]byte(msgstr))
+	require.NoError(t, err)
+
+	req, ok := msg.(*Request)
+	require.True(t, ok)
+	assert.Equal(t, INVITE, req.Method)
+	assert.Equal(t, "urn", req.Recipient.Scheme)
+	assert.Equal(t, "service:sos", req.Recipient.Opaque)
+	assert.Equal(t, "urn:service:sos", req.Recipient.String())
+
+	to := msg.To()
+	require.NotNil(t, to)
+	assert.Equal(t, "service:sos", to.Address.Opaque)
+
+	assert.Equal(t, msgstr, msg.String())
+}
+
 func TestParseRequestFoldedHeaders(t *testing.T) {
 	rawMsg := []string{
 		"INVITE sip:bob@127.0.0.1:5060 SIP/2.0",

--- a/sip/uri.go
+++ b/sip/uri.go
@@ -12,6 +12,16 @@ import (
 type Uri struct {
 	Scheme string
 
+	// Opaque is the scheme specific part of a URI that has no user, host or
+	// port to parse into. A URN (RFC 2141) is the case SIP meets: its
+	// namespace specific string is opaque by definition, and the colons in it
+	// separate namespaces rather than introducing a port.
+	//
+	// It is carried and rendered exactly as it arrived, so a URN round trips
+	// byte for byte. Empty for every sip:, sips: and tel: URI, so nothing that
+	// does not use a URN is affected.
+	Opaque string
+
 	// If value is star (*)
 	Wildcard bool
 
@@ -64,6 +74,15 @@ func (uri *Uri) StringWrite(buffer io.StringWriter) {
 	buffer.WriteString(scheme)
 	buffer.WriteString(":")
 
+	// A URN has no user, host or port: its namespace specific string is opaque
+	// and is written back exactly as it was read. Parameters and headers still
+	// follow, because a URN in a To or From header is entitled to carry them.
+	if uri.Opaque != "" {
+		buffer.WriteString(uri.Opaque)
+		uri.stringWriteParams(buffer)
+		return
+	}
+
 	if uri.HierarhicalSlashes {
 		buffer.WriteString("//")
 	}
@@ -87,6 +106,12 @@ func (uri *Uri) StringWrite(buffer io.StringWriter) {
 		buffer.WriteString(strconv.Itoa(uri.Port))
 	}
 
+	uri.stringWriteParams(buffer)
+}
+
+// stringWriteParams writes the uri-parameters and headers, the tail a sip: URI
+// and a URN have in common.
+func (uri *Uri) stringWriteParams(buffer io.StringWriter) {
 	if (uri.UriParams != nil) && uri.UriParams.Length() > 0 {
 		buffer.WriteString(";")
 		buffer.WriteString(uri.UriParams.ToString(';'))


### PR DESCRIPTION
### The bug

`ParseUri` splits everything after the scheme into user, host and port, so a URN's namespace specific string is read as a port:

```go
u := &sip.Uri{}
err := sip.ParseUri("urn:service:sos", u)
// err          strconv.Atoi: parsing "sos": invalid syntax
// u.Host       "service"
// u.String()   "urn:service"
```

It does not just error — the NSS is dropped and the URI left corrupt. Through `parseRequestLine` the error rejects the whole message, so `INVITE urn:service:sos SIP/2.0` never reaches a handler.

That is the [RFC 5031](https://datatracker.ietf.org/doc/html/rfc5031) emergency call, which [3GPP TS 24.229](https://www.3gpp.org/DynaReport/24229.htm) §5.1.6.8.1 requires the network to accept; `urn:uuid:` (`+sip.instance`) fails identically. Both are `absoluteURI`s, admitted as Request-URIs by [RFC 3261](https://datatracker.ietf.org/doc/html/rfc3261#section-7.1) §7.1 — and `Uri`'s doc comment already says the scheme *"can be tel, urn"*.

### The change

The NSS is opaque by definition ([RFC 2141](https://datatracker.ietf.org/doc/html/rfc2141)), so it goes verbatim into a new `Opaque` field and `StringWrite` renders it back unsplit. `Opaque` stays empty for `sip:`, `sips:` and `tel:`, so nothing else is affected.

It runs to the end of the URI on purpose: `;` is a legal NSS character and `uri-parameters` are SIP/SIPS-only (RFC 3261 §19.1.1), so splitting there would corrupt a valid URN.

A deliberately narrow form of the "unparsed" state proposed in point 3 of #125 — limited to the one scheme whose absence loses a call, and no obstacle to the extendable parser that issue asks for.

### Tests

`TestParseUriURN` (8 subtests) and `TestParseRequestURN`, in the existing style. Mutation-verified: disabling the new branch turns every parse-dependent subtest red and leaves the `sip:` control green. Full suite passes.
