### PR TITLE
fix(transport): close pooled connection on last reference, never hand out a closed one

### DIFF
--- a/sip/transport_connection_pool.go
+++ b/sip/transport_connection_pool.go
@@ -141,19 +141,36 @@ func (p *connectionPool) getUnref(a string) (c Connection) {
 	if !exists {
 		return nil
 	}
+	// A closed connection can still sit in the pool: one connection is stored
+	// under several keys (remote and local address, and for the UDP listener
+	// every peer it accepted), while closing removes them one at a time.
+	// Handing such a connection out sends the caller to a socket that is
+	// already gone instead of letting it dial a new one, and Ref pulls the
+	// count of a closed connection back above zero, so the next TryClose
+	// closes it a second time. Asked through an anonymous interface to keep
+	// the exported Connection interface unchanged.
+	if closer, ok := c.(interface{ Closed() bool }); ok && closer.Closed() {
+		return nil
+	}
 	return c
 }
 
-// CloseAndDelete closes connection and deletes from pool
+// CloseAndDelete deletes connection from pool and releases the reference held
+// by its reader.
+//
+// It used to force a hard Close whenever references remained, which defeats
+// the reference counting the pool is built on: the socket is taken away from
+// the owners still holding it, and Close resets refcount to 0, so their later
+// TryClose runs on a connection that is already gone. TryClose closes as soon
+// as the last reference is released, which is the only point where closing is
+// safe. Readers give up the idle reference (TransportIdleConnection) before
+// calling this, so a connection leaving the pool still reaches zero.
 func (p *connectionPool) CloseAndDelete(c Connection, addr string) error {
 	p.Lock()
 	defer p.Unlock()
 	delete(p.m, addr)
-	ref, _ := c.TryClose() // Be nice. Saves from double closing
-	if ref > 0 {
-		return c.Close()
-	}
-	return nil
+	_, err := c.TryClose()
+	return err
 }
 
 func (p *connectionPool) Delete(addr string) {

--- a/sip/transport_connection_pool_test.go
+++ b/sip/transport_connection_pool_test.go
@@ -1,8 +1,11 @@
 package sip
 
 import (
+	"bytes"
 	"net"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/emiago/sipgo/fakes"
 )
@@ -45,5 +48,161 @@ func BenchmarkConnectionPool(b *testing.B) {
 		if c != conn {
 			b.Fatal("mismatched function")
 		}
+	}
+}
+
+// closeCountingConn counts Close calls so a test can tell a connection that was
+// closed once from one closed under an owner that still holds a reference.
+type closeCountingConn struct {
+	*fakes.TCPConn
+	closes atomic.Int32
+}
+
+func (c *closeCountingConn) Close() error {
+	c.closes.Add(1)
+	return nil
+}
+
+func newCountingConn() *closeCountingConn {
+	return &closeCountingConn{TCPConn: &fakes.TCPConn{
+		LAddr: net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5060},
+		RAddr: net.TCPAddr{IP: net.ParseIP("127.0.0.2"), Port: 5060},
+	}}
+}
+
+// CloseAndDelete must not close a connection other owners still hold: the pool
+// is built on reference counting and the last reference does the closing.
+func TestConnectionPoolCloseAndDeleteKeepsLiveReference(t *testing.T) {
+	pool := newConnectionPool()
+	fake := newCountingConn()
+	// 1 reference for the reader, 1 for an owner in the middle of a request
+	conn := &TCPConnection{Conn: fake, refcount: 2}
+	pool.Add(fake.RAddr.String(), conn)
+
+	if err := pool.CloseAndDelete(conn, fake.RAddr.String()); err != nil {
+		t.Fatalf("CloseAndDelete: %v", err)
+	}
+	if n := fake.closes.Load(); n != 0 {
+		t.Fatalf("connection closed %d times with a reference left", n)
+	}
+	if ref := conn.Ref(0); ref != 1 {
+		t.Fatalf("references left = %d, want 1", ref)
+	}
+
+	if _, err := conn.TryClose(); err != nil {
+		t.Fatalf("TryClose: %v", err)
+	}
+	if n := fake.closes.Load(); n != 1 {
+		t.Fatalf("connection closed %d times after the last reference, want 1", n)
+	}
+}
+
+// A connection is stored under more than one key, so closing it leaves the
+// other keys pointing at a socket that is gone. Handing it out again also pulls
+// its reference count back above zero, and the next TryClose closes it twice.
+func TestConnectionPoolDoesNotReturnClosedConnection(t *testing.T) {
+	pool := newConnectionPool()
+	fake := newCountingConn()
+	conn := &TCPConnection{Conn: fake, refcount: 1}
+	pool.Add(fake.RAddr.String(), conn)
+	pool.Add(fake.LAddr.String(), conn)
+
+	if err := pool.CloseAndDelete(conn, fake.RAddr.String()); err != nil {
+		t.Fatalf("CloseAndDelete: %v", err)
+	}
+	if n := fake.closes.Load(); n != 1 {
+		t.Fatalf("last reference closed the connection %d times, want 1", n)
+	}
+	if c := pool.Get(fake.LAddr.String()); c != nil {
+		t.Fatal("pool returned a closed connection")
+	}
+	if n := fake.closes.Load(); n != 1 {
+		t.Fatalf("connection closed %d times in total, want 1", n)
+	}
+}
+
+// The reader exiting takes the connection out of the pool, so the idle
+// reference kept for reuse has to go with it. Otherwise nothing ever releases
+// it and the socket stays open for the life of the process.
+func TestTCPReadConnectionReleasesIdleReference(t *testing.T) {
+	layer := NewTransportLayer(net.DefaultResolver, NewParser(), nil)
+	t.Cleanup(func() { _ = layer.Close() })
+
+	fake := newCountingConn()
+	// an empty reader ends the read loop at once, as a peer closing would
+	fake.Reader = bytes.NewReader(nil)
+	conn := layer.tcp.initConnection(fake, fake.RAddr.String(), func(m Message) {})
+
+	deadline := time.Now().Add(time.Second)
+	for conn.Ref(0) > 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if ref := conn.Ref(0); ref != 0 {
+		t.Fatalf("references left after the reader stopped = %d, want 0", ref)
+	}
+	if n := fake.closes.Load(); n != 1 {
+		t.Fatalf("connection closed %d times, want 1", n)
+	}
+	if c := layer.tcp.GetConnection(fake.RAddr.String()); c != nil {
+		t.Fatal("closed connection left in the pool")
+	}
+}
+
+// A UDP listener sits in the pool under every peer it accepted, and those keys
+// are dropped one at a time. Once its last reference is gone its reader has
+// stopped, so the pool must not hand it out: the caller would be sent to a
+// socket nothing reads instead of dialing a new connection.
+//
+// TryClose returns early for a listener — closing the socket is the caller's
+// job — and used to return before marking the connection closed, so the flag
+// that keeps closed connections out of the pool never got set for the one
+// connection type that has the most keys.
+func TestConnectionPoolDoesNotReturnClosedListener(t *testing.T) {
+	pool := newConnectionPool()
+	fake := &fakes.UDPConn{
+		LAddr: net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5060},
+		RAddr: net.UDPAddr{IP: net.ParseIP("127.0.0.2"), Port: 5060},
+	}
+	conn := &UDPConnection{PacketConn: fake, PacketAddr: fake.LAddr.String(), Listener: true}
+
+	// the address it listens on, plus a peer it accepted
+	pool.Add(fake.LAddr.String(), conn)
+	pool.Add(fake.RAddr.String(), conn)
+
+	if err := pool.CloseAndDelete(conn, fake.LAddr.String()); err != nil {
+		t.Fatalf("CloseAndDelete: %v", err)
+	}
+	if !conn.Closed() {
+		t.Fatal("listener not marked closed after its last reference was released")
+	}
+	if c := pool.Get(fake.RAddr.String()); c != nil {
+		t.Fatal("pool returned a closed listener")
+	}
+}
+
+// A listener other owners still hold is not marked closed: they may still send
+// on it, and the socket is closed by whoever opened it, not by the pool.
+func TestConnectionPoolKeepsListenerWithLiveReference(t *testing.T) {
+	pool := newConnectionPool()
+	fake := &fakes.UDPConn{
+		LAddr: net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5060},
+		RAddr: net.UDPAddr{IP: net.ParseIP("127.0.0.2"), Port: 5060},
+	}
+	// 1 reference for the reader, 1 for an owner in the middle of a request
+	conn := &UDPConnection{
+		PacketConn: fake, PacketAddr: fake.LAddr.String(),
+		Listener: true, refcount: 2,
+	}
+	pool.Add(fake.LAddr.String(), conn)
+	pool.Add(fake.RAddr.String(), conn)
+
+	if err := pool.CloseAndDelete(conn, fake.LAddr.String()); err != nil {
+		t.Fatalf("CloseAndDelete: %v", err)
+	}
+	if conn.Closed() {
+		t.Fatal("listener marked closed with a reference left")
+	}
+	if c := pool.Get(fake.RAddr.String()); c == nil {
+		t.Fatal("pool dropped a listener its owner still holds")
 	}
 }

--- a/sip/transport_tcp.go
+++ b/sip/transport_tcp.go
@@ -165,6 +165,11 @@ func (t *TransportTCP) readConnection(conn *TCPConnection, laddr string, raddr s
 	buf := make([]byte, TransportBufferReadSize)
 	defer t.pool.Delete(laddr)
 	defer func() {
+		// The idle reference keeps the connection in the pool for reuse. Its
+		// reader is gone, so the connection is leaving the pool and cannot be
+		// reused: without releasing that reference here the count never
+		// reaches zero and the socket stays open for the life of the process.
+		conn.Ref(-TransportIdleConnection)
 		if err := t.pool.CloseAndDelete(conn, raddr); err != nil {
 			t.log.Warn("connection pool not clean cleanup", "error", err)
 		}
@@ -264,6 +269,19 @@ type TCPConnection struct {
 
 	mu       sync.RWMutex
 	refcount int
+	// closed marks a connection whose socket is already released. The pool
+	// keeps a connection under several keys and drops them one at a time, so
+	// without this flag Get still returns it after closing.
+	closed bool
+}
+
+// Closed reports a connection that is already closed, so the pool does not
+// hand it out again. Not part of the Connection interface: the pool asks for
+// it through an anonymous interface.
+func (c *TCPConnection) Closed() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.closed
 }
 
 func (c *TCPConnection) Ref(i int) int {
@@ -278,6 +296,7 @@ func (c *TCPConnection) Ref(i int) int {
 func (c *TCPConnection) Close() error {
 	c.mu.Lock()
 	c.refcount = 0
+	c.closed = true
 	c.mu.Unlock()
 	DefaultLogger().Debug("TCP doing hard close", "ip", c.LocalAddr().String(), "dst", c.RemoteAddr().String(), "ref", 0)
 	return c.Conn.Close()
@@ -287,6 +306,9 @@ func (c *TCPConnection) TryClose() (int, error) {
 	c.mu.Lock()
 	c.refcount--
 	ref := c.refcount
+	if ref <= 0 {
+		c.closed = true
+	}
 	c.mu.Unlock()
 	DefaultLogger().Debug("TCP reference decrement", "ip", c.LocalAddr().String(), "dst", c.RemoteAddr().String(), "ref", ref)
 	if ref > 0 {

--- a/sip/transport_udp.go
+++ b/sip/transport_udp.go
@@ -124,6 +124,15 @@ func (t *TransportUDP) readUDPConnection(conn *UDPConnection, raddr string, ladd
 func (t *TransportUDP) readListenerConnection(conn *UDPConnection, laddr string, handler MessageHandler) {
 	buf := make([]byte, TransportBufferReadSize)
 	defer func() {
+		if !conn.Listener {
+			// The idle reference keeps a dialed connection in the pool for
+			// reuse. Its reader is gone, so the connection is leaving the
+			// pool and cannot be reused: without releasing that reference
+			// here the count never reaches zero and the socket stays open
+			// for the life of the process. A listener carries no such
+			// reference, it is added to the pool with a single one.
+			conn.Ref(-TransportIdleConnection)
+		}
 		if err := t.pool.CloseAndDelete(conn, laddr); err != nil {
 			t.log.Warn("connection pool not clean cleanup", "error", err)
 		}
@@ -243,11 +252,25 @@ type UDPConnection struct {
 
 	mu       sync.RWMutex
 	refcount int
+	// closed marks a connection whose socket is already released. The pool
+	// keeps a connection under several keys and drops them one at a time, so
+	// without this flag Get still returns it after closing.
+	closed bool
+}
+
+// Closed reports a connection that is already closed, so the pool does not
+// hand it out again. Not part of the Connection interface: the pool asks for
+// it through an anonymous interface.
+func (c *UDPConnection) Closed() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.closed
 }
 
 func (c *UDPConnection) close() error {
 	c.mu.Lock()
 	c.refcount = 0
+	c.closed = true
 	c.mu.Unlock()
 
 	if c.Listener {
@@ -279,10 +302,17 @@ func (c *UDPConnection) TryClose() (int, error) {
 	c.mu.Lock()
 	c.refcount--
 	ref := c.refcount
+	if ref <= 0 {
+		c.closed = true
+	}
 	c.mu.Unlock()
 
 	if c.Listener {
-		// Listeners must be closed manually or by forcing error
+		// Listeners must be closed manually or by forcing error, so this
+		// does not touch the socket. It still marks the connection closed
+		// once the last reference is gone: the listener is kept in the pool
+		// under every peer it accepted, and its reader has stopped, so
+		// handing it out would send the caller to a socket nothing reads.
 		return ref, nil
 	}
 

--- a/sip/transport_ws.go
+++ b/sip/transport_ws.go
@@ -192,6 +192,11 @@ func (t *TransportWS) readConnection(conn *WSConnection, laddr string, raddr str
 	// defer t.pool.Del(raddr)
 	defer t.pool.Delete(laddr)
 	defer func() {
+		// The idle reference keeps the connection in the pool for reuse. Its
+		// reader is gone, so the connection is leaving the pool and cannot be
+		// reused: without releasing that reference here the count never
+		// reaches zero and the socket stays open for the life of the process.
+		conn.Ref(-TransportIdleConnection)
 		if err := t.pool.CloseAndDelete(conn, raddr); err != nil {
 			t.log.Warn("connection pool not clean cleanup", "error", err)
 		}
@@ -333,6 +338,19 @@ type WSConnection struct {
 
 	mu       sync.RWMutex
 	refcount int
+	// closed marks a connection whose socket is already released. The pool
+	// keeps a connection under several keys and drops them one at a time, so
+	// without this flag Get still returns it after closing.
+	closed bool
+}
+
+// Closed reports a connection that is already closed, so the pool does not
+// hand it out again. Not part of the Connection interface: the pool asks for
+// it through an anonymous interface.
+func (c *WSConnection) Closed() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.closed
 }
 
 func (c *WSConnection) Ref(i int) int {
@@ -348,6 +366,7 @@ func (c *WSConnection) Ref(i int) int {
 func (c *WSConnection) Close() error {
 	c.mu.Lock()
 	c.refcount = 0
+	c.closed = true
 	c.mu.Unlock()
 	DefaultLogger().Debug("WS doing hard close", "ip", c.RemoteAddr().String())
 	return c.Conn.Close()
@@ -357,6 +376,9 @@ func (c *WSConnection) TryClose() (int, error) {
 	c.mu.Lock()
 	c.refcount--
 	ref := c.refcount
+	if ref <= 0 {
+		c.closed = true
+	}
 	c.mu.Unlock()
 	DefaultLogger().Debug("WS reference decrement", "ip", c.RemoteAddr().String(), "ref", ref)
 	if ref > 0 {


### PR DESCRIPTION
### Problem

`connectionPool` is reference counted: `Get` takes a reference, `TryClose`
gives one back and closes the connection once the last one is gone.
`CloseAndDelete` steps outside that contract in two ways.

**It force closes.** `TryClose` is called first ("Be nice. Saves from double
closing"), but when references remain the connection is closed anyway:

```go
ref, _ := c.TryClose()
if ref > 0 {
    return c.Close()
}

The owners still holding the connection — a client transaction waiting for a response, a server transaction about to answer — lose the socket from under them, and Close resets refcount to 0, so their own TryClose runs against a connection that is already gone and takes the count negative ("ref went negative" in the log).

It removes one key. A connection is stored in the pool under several keys: the remote and the local address when it is created (addSingleflight), and for the UDP listener every peer it has accepted (readListenerConnection → pool.Add(rastr, conn)). CloseAndDelete deletes the key it is handed, so after closing the connection is still reachable through the others. The next request for that peer is given a socket that is closed instead of dialing a new connection, and Get pulls the reference count of a closed connection back above zero — so the TryClose that follows closes it a second time.

Fix
CloseAndDelete releases the reader's reference and nothing more; the connection is closed by whoever releases the last reference, which is the only moment closing is safe.

A connection that is already closed is not returned from the pool. UDPConnection, TCPConnection and WSConnection gained a Closed() method, and getUnref asks for it through an anonymous interface, so the exported Connection interface is unchanged and an implementation outside the library keeps working (it simply gets the old behaviour).

A UDP listener is marked closed by the same rule. Its TryClose returns early — closing a listener's socket is the caller's job, not the pool's — and it used to return before the connection was marked, leaving closed unset for the one connection type that carries the most keys, since readListenerConnection adds the listener under every peer it accepts. Once its last reference is gone its reader has stopped, so handing it out sends the caller to a socket nothing reads. The socket itself is still not touched there; only the flag is set, and only when the last reference is released.

Readers give up the idle reference (TransportIdleConnection) before evicting the connection. That reference exists to keep an idle connection in the pool for reuse, and a connection whose reader has stopped cannot be reused; without releasing it the count would never reach zero and the descriptor would stay open for the life of the process, since the force close was what used to reclaim it. The UDP listener carries no such reference — it is added to the pool with a single one — so there the release is skipped.

Tests
TestConnectionPoolCloseAndDeleteKeepsLiveReference — a connection with a reader and one owner: CloseAndDelete must leave the socket open, and the owner's TryClose must close it exactly once. Fails on the current code, where the connection is closed while the owner still holds it.
TestConnectionPoolDoesNotReturnClosedConnection — a connection stored under two keys: after it is closed, Get on the other key must return nothing, and the connection must not be closed twice. Fails on the current code, where the closed connection is handed out again.
TestConnectionPoolDoesNotReturnClosedListener — a UDP listener stored under its own address and under a peer it accepted: after the last reference is released it must be marked closed, and Get on the peer key must return nothing. Fails on the current code, where TryClose returns before marking a listener and the pool keeps serving it.
TestConnectionPoolKeepsListenerWithLiveReference — the same listener with an owner left: it must not be marked closed and must stay available through the other key.
TestTCPReadConnectionReleasesIdleReference — the reader of an accepted TCP connection stops: the connection must end up with no references, be closed once and be gone from the pool. This is the guard for the idle reference; without releasing it the connection is left at one reference forever.
go test ./... in the library is green with the change. TestTransportLayerClientConnectionReuse and ...NoReuse fail under -race both with and without it — that is the state of main (the race is between require.NotEqual, which walks the connection with reflection, and the read goroutine).

Compatibility
No public API change: Closed() is an addition, asked for through an anonymous interface, and the Connection interface is untouched. What changes is the moment a pooled connection is closed — when its last owner lets go instead of when its reader stops — and that a closed connection is no longer served from the pool.